### PR TITLE
Generate Query and Mutation struct

### DIFF
--- a/clientgen/client.go
+++ b/clientgen/client.go
@@ -31,31 +31,44 @@ func (p *Plugin) MutateConfig(cfg *config.Config) error {
 	}
 
 	// 1. 全体のqueryDocumentを1度にparse
+	// 1. Parse document from source of query
 	queryDocument, err := ParseQueryDocuments(cfg.Schema, querySources)
 	if err != nil {
 		return xerrors.Errorf(": %w", err)
 	}
 
 	// 2. OperationごとのqueryDocumentを作成
+	// 2. Separate documents for each operation
 	queryDocuments, err := QueryDocumentsByOperations(cfg.Schema, queryDocument.Operations)
 	if err != nil {
 		return xerrors.Errorf("parse query document failed: %w", err)
 	}
 
 	// 3. テンプレートと情報ソースを元にコード生成
+	// 3. Generate code from template and document source
 	sourceGenerator := NewSourceGenerator(cfg, p.Client)
-	source := NewSource(queryDocument, sourceGenerator)
-	fragments, err := source.fragments()
+	source := NewSource(cfg.Schema, queryDocument, sourceGenerator)
+	query, err := source.Query()
+	if err != nil {
+		return xerrors.Errorf("generating query object: %w", err)
+	}
+
+	mutation, err := source.Mutation()
+	if err != nil {
+		return xerrors.Errorf("generating mutation object: %w", err)
+	}
+
+	fragments, err := source.Fragments()
 	if err != nil {
 		return xerrors.Errorf("generating fragment failed: %w", err)
 	}
 
-	operationResponses, err := source.operationResponses()
+	operationResponses, err := source.OperationResponses()
 	if err != nil {
 		return xerrors.Errorf("generating operation response failed: %w", err)
 	}
 
-	if err := RenderTemplate(cfg, fragments, source.operations(queryDocuments), operationResponses, p.Client); err != nil {
+	if err := RenderTemplate(cfg, query, mutation, fragments, source.Operations(queryDocuments), operationResponses, p.Client); err != nil {
 		return xerrors.Errorf("template failed: %w", err)
 	}
 

--- a/clientgen/template.go
+++ b/clientgen/template.go
@@ -6,11 +6,13 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func RenderTemplate(cfg *config.Config, fragments []*Fragment, operations []*Operation, operationResponses []*OperationResponse, client config.PackageConfig) error {
+func RenderTemplate(cfg *config.Config, query *Query, mutation *Mutation, fragments []*Fragment, operations []*Operation, operationResponses []*OperationResponse, client config.PackageConfig) error {
 	if err := templates.Render(templates.Options{
 		PackageName: client.Package,
 		Filename:    client.Filename,
 		Data: map[string]interface{}{
+			"Query":             query,
+			"Mutation":          mutation,
 			"Fragment":          fragments,
 			"Operation":         operations,
 			"OperationResponse": operationResponses,

--- a/clientgen/template.gotpl
+++ b/clientgen/template.gotpl
@@ -18,6 +18,10 @@ type Client struct {
 	Client *client.Client
 }
 
+type {{ .Query.Name | go }} {{ .Query.Type | ref }}
+
+type {{ .Mutation.Name | go }} {{ .Mutation.Type | ref }}
+
 {{- range $name, $element := .Fragment }}
 	type  {{ .Name | go  }} {{ .Type | ref }}
 {{- end }}


### PR DESCRIPTION
Don't generate Query and Mutation type struct by gqlgen. It is correct because it's server lib. But gqlgenc is a client lib. So gqlgenc need Query and Mutation struct. 
For example, [Shopify Admin API](https://shopify.dev/docs/admin-api) use Query in [the Job](https://shopify.dev/docs/admin-api/graphql/reference/object/job).