### PR TITLE
error handling implementation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -4,14 +4,18 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 
-	"github.com/Yamashou/gqlgenc/graphqljson"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 	"golang.org/x/xerrors"
 )
 
+// HTTPRequestOption represents the options applicable to the http client
 type HTTPRequestOption func(req *http.Request)
 
+// Client is the http client wrapper
 type Client struct {
 	Client             *http.Client
 	BaseURL            string
@@ -25,6 +29,7 @@ type Request struct {
 	OperationName string                 `json:"operationName,omitempty"`
 }
 
+// NewClient creates a new http client wrapper
 func NewClient(client *http.Client, baseURL string, options ...HTTPRequestOption) *Client {
 	return &Client{
 		Client:             client,
@@ -60,6 +65,45 @@ func (c *Client) newRequest(ctx context.Context, query string, vars map[string]i
 	return req, nil
 }
 
+// GqlErrorList is the struct of a standard graphql error response
+type GqlErrorList struct {
+	Errors gqlerror.List `json:"errors"`
+}
+
+func (e *GqlErrorList) Error() string {
+	return e.Errors.Error()
+}
+
+// HTTPError is the error when a GqlErrorList cannot be parsed
+type HTTPError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// ErrorResponse represent an handled error
+type ErrorResponse struct {
+	// populated when http status code is not OK
+	NetworkError *HTTPError `json:"networkErrors"`
+	// populated when http status code is OK but the server returned at least one graphql error
+	GqlErrors *gqlerror.List `json:"graphqlErrors"`
+}
+
+// HasErrors returns true when at least one error is declared
+func (er *ErrorResponse) HasErrors() bool {
+	if er.NetworkError != nil || er.GqlErrors != nil {
+		return true
+	}
+	return false
+}
+
+func (er *ErrorResponse) Error() string {
+	content, err := json.Marshal(er)
+	if err != nil {
+		return err.Error()
+	}
+	return string(content)
+}
+
 // Post sends a http POST request to the graphql endpoint with the given query then unpacks
 // the response into the given object.
 func (c *Client) Post(ctx context.Context, query string, respData interface{}, vars map[string]interface{}, httpRequestOptions ...HTTPRequestOption) error {
@@ -76,12 +120,61 @@ func (c *Client) Post(ctx context.Context, query string, respData interface{}, v
 	}
 	defer resp.Body.Close()
 
-	if err := graphqljson.Unmarshal(resp.Body, respData); err != nil {
-		return err
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return xerrors.Errorf("failed to read response body: %w", err)
 	}
 
-	if resp.StatusCode < 200 || 299 < resp.StatusCode {
-		return xerrors.Errorf("http status code: %v", resp.StatusCode)
+	return parseResponse(body, resp.StatusCode, respData)
+}
+
+func parseResponse(body []byte, httpCode int, result interface{}) error {
+	errResponse := &ErrorResponse{}
+	if httpCode < 200 || 299 < httpCode {
+		errResponse.NetworkError = &HTTPError{
+			Code:    httpCode,
+			Message: fmt.Sprintf("Response body %s", string(body)),
+		}
+	} else {
+		if err := unmarshal(body, &result); err != nil {
+			if gqlErr, ok := err.(*GqlErrorList); ok {
+				errResponse.GqlErrors = &gqlErr.Errors
+			} else {
+				return err
+			}
+		}
+	}
+
+	if errResponse.HasErrors() {
+		return errResponse
+	}
+
+	return nil
+}
+
+// response is a GraphQL layer response from a handler.
+type response struct {
+	Data   json.RawMessage `json:"data"`
+	Errors json.RawMessage `json:"errors"`
+}
+
+func unmarshal(data []byte, res interface{}) error {
+	resp := response{}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return xerrors.Errorf("failed to decode data %s: %w", string(data), err)
+	}
+
+	if resp.Errors != nil && len(resp.Errors) > 0 {
+		// try to parse standard graphql error
+		errors := &GqlErrorList{}
+		if e := json.Unmarshal(data, errors); e != nil {
+			return xerrors.Errorf("faild to parse graphql errors. Response content %s - %w ", string(data), e)
+		}
+		return errors
+	}
+
+	if err := json.Unmarshal(resp.Data, &res); err != nil {
+		return xerrors.Errorf("failed to decode data into response %s: %w", string(data), err)
 	}
 
 	return nil

--- a/client/client.go
+++ b/client/client.go
@@ -135,13 +135,11 @@ func parseResponse(body []byte, httpCode int, result interface{}) error {
 			Code:    httpCode,
 			Message: fmt.Sprintf("Response body %s", string(body)),
 		}
-	} else {
-		if err := unmarshal(body, &result); err != nil {
-			if gqlErr, ok := err.(*GqlErrorList); ok {
-				errResponse.GqlErrors = &gqlErr.Errors
-			} else {
-				return err
-			}
+	} else if err := unmarshal(body, &result); err != nil {
+		if gqlErr, ok := err.(*GqlErrorList); ok {
+			errResponse.GqlErrors = &gqlErr.Errors
+		} else {
+			return err
 		}
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -136,7 +136,7 @@ func parseResponse(body []byte, httpCode int, result interface{}) error {
 			Code:    httpCode,
 			Message: fmt.Sprintf("Response body %s", string(body)),
 		}
-	} else if err := unmarshal(body, &result); err != nil {
+	} else if err := unmarshal(body, result); err != nil {
 		if gqlErr, ok := err.(*GqlErrorList); ok {
 			errResponse.GqlErrors = &gqlErr.Errors
 		} else {
@@ -159,7 +159,7 @@ type response struct {
 
 func unmarshal(data []byte, res interface{}) error {
 	resp := response{}
-	if err := graphqljson.UnmarshalData(data, &resp); err != nil {
+	if err := json.Unmarshal(data, &resp); err != nil {
 		return xerrors.Errorf("failed to decode data %s: %w", string(data), err)
 	}
 
@@ -172,7 +172,7 @@ func unmarshal(data []byte, res interface{}) error {
 		return errors
 	}
 
-	if err := json.Unmarshal(resp.Data, &res); err != nil {
+	if err := graphqljson.UnmarshalData(resp.Data, res); err != nil {
 		return xerrors.Errorf("failed to decode data into response %s: %w", string(data), err)
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/Yamashou/gqlgenc/graphqljson"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"golang.org/x/xerrors"
 )
@@ -150,15 +151,9 @@ func parseResponse(body []byte, httpCode int, result interface{}) error {
 	return nil
 }
 
-// response is a GraphQL layer response from a handler.
-type response struct {
-	Data   json.RawMessage `json:"data"`
-	Errors json.RawMessage `json:"errors"`
-}
-
 func unmarshal(data []byte, res interface{}) error {
-	resp := response{}
-	if err := json.Unmarshal(data, &resp); err != nil {
+	resp := graphqljson.Response{}
+	if err := graphqljson.UnmarshalData(data, &resp); err != nil {
 		return xerrors.Errorf("failed to decode data %s: %w", string(data), err)
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -151,8 +151,14 @@ func parseResponse(body []byte, httpCode int, result interface{}) error {
 	return nil
 }
 
+// response is a GraphQL layer response from a handler.
+type response struct {
+	Data   json.RawMessage `json:"data"`
+	Errors json.RawMessage `json:"errors"`
+}
+
 func unmarshal(data []byte, res interface{}) error {
-	resp := graphqljson.Response{}
+	resp := response{}
 	if err := graphqljson.UnmarshalData(data, &resp); err != nil {
 		return xerrors.Errorf("failed to decode data %s: %w", string(data), err)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -177,9 +177,23 @@ func TestParseResponse(t *testing.T) {
 		require.IsType(t, expectedType, err)
 	})
 
-	t.Run("network error", func(t *testing.T) {
+	t.Run("network error with valid gql error response", func(t *testing.T) {
 		r := &fakeRes{}
 		err := parseResponse([]byte(qqlSingleErr), 400, r)
+
+		expectedType := &ErrorResponse{}
+		require.IsType(t, expectedType, err)
+
+		netExpectedType := &HTTPError{}
+		require.IsType(t, netExpectedType, err.(*ErrorResponse).NetworkError)
+
+		gqlExpectedType := &gqlerror.List{}
+		require.IsType(t, gqlExpectedType, err.(*ErrorResponse).GqlErrors)
+	})
+
+	t.Run("network error with not valid gql error response", func(t *testing.T) {
+		r := &fakeRes{}
+		err := parseResponse([]byte(invalidJSON), 500, r)
 
 		expectedType := &ErrorResponse{}
 		require.IsType(t, expectedType, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,200 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	"golang.org/x/xerrors"
+)
+
+const (
+	qqlSingleErr        = `{"errors":[{"path":["query GetUser","viewer","repositories","nsodes"],"extensions":{"code":"undefinedField","typeName":"RepositoryConnection","fieldName":"nsodes"},"locations":[{"line":6,"column":4}],"message":"Field 'nsodes' doesn't exist on type 'RepositoryConnection'"}]}`
+	gqlMultipleErr      = `{"errors":[{"path":["query GetUser","viewer","repositories","nsodes"],"extensions":{"code":"undefinedField","typeName":"RepositoryConnection","fieldName":"nsodes"},"locations":[{"line":6,"column":4}],"message":"Field 'nsodes' doesn't exist on type 'RepositoryConnection'"},{"path":["query GetUser"],"extensions":{"code":"variableNotUsed","variableName":"languageFirst"},"locations":[{"line":1,"column":1}],"message":"Variable $languageFirst is declared by GetUser but not used"},{"path":["fragment LanguageFragment"],"extensions":{"code":"useAndDefineFragment","fragmentName":"LanguageFragment"},"locations":[{"line":18,"column":1}],"message":"Fragment LanguageFragment was defined, but not used"}]}`
+	gqlDataAndErr       = `{"data": {"something": "some data"},"errors":[{"path":["query GetUser","viewer","repositories","nsodes"],"extensions":{"code":"undefinedField","typeName":"RepositoryConnection","fieldName":"nsodes"},"locations":[{"line":6,"column":4}],"message":"Field 'nsodes' doesn't exist on type 'RepositoryConnection'"}]}`
+	invalidJSON         = "invalid"
+	validData           = `{"data":{"something": "some data"}}`
+	withBadDataFormat   = `{"data": "notAndObject"}`
+	withBadErrorsFormat = `{"errors": "bad"}`
+)
+
+type fakeRes struct {
+	Something string `json:"something"`
+}
+
+func TestUnmarshal(t *testing.T) {
+
+	t.Run("single error", func(t *testing.T) {
+		var path ast.Path
+		json.Unmarshal([]byte(`["query GetUser","viewer","repositories","nsodes"]`), &path)
+		r := &fakeRes{}
+		err := unmarshal([]byte(qqlSingleErr), r)
+		expectedErr := &GqlErrorList{
+			Errors: gqlerror.List{{
+				Message: "Field 'nsodes' doesn't exist on type 'RepositoryConnection'",
+				Path:    path,
+				Locations: []gqlerror.Location{{
+					Line:   6,
+					Column: 4,
+				}},
+				Extensions: map[string]interface{}{
+					"code":      "undefinedField",
+					"typeName":  "RepositoryConnection",
+					"fieldName": "nsodes",
+				},
+			}},
+		}
+		require.Equal(t, err, expectedErr)
+	})
+
+	t.Run("multiple errors", func(t *testing.T) {
+		var path1 ast.Path
+		json.Unmarshal([]byte(`["query GetUser","viewer","repositories","nsodes"]`), &path1)
+		var path2 ast.Path
+		json.Unmarshal([]byte(`["query GetUser"]`), &path2)
+		var path3 ast.Path
+		json.Unmarshal([]byte(`["fragment LanguageFragment"]`), &path3)
+		r := &fakeRes{}
+		err := unmarshal([]byte(gqlMultipleErr), r)
+		expectedErr := &GqlErrorList{
+			Errors: gqlerror.List{
+				{
+					Message: "Field 'nsodes' doesn't exist on type 'RepositoryConnection'",
+					Path:    path1,
+					Locations: []gqlerror.Location{{
+						Line:   6,
+						Column: 4,
+					}},
+					Extensions: map[string]interface{}{
+						"code":      "undefinedField",
+						"typeName":  "RepositoryConnection",
+						"fieldName": "nsodes",
+					},
+				},
+				{
+					Message: "Variable $languageFirst is declared by GetUser but not used",
+					Path:    path2,
+					Locations: []gqlerror.Location{{
+						Line:   1,
+						Column: 1,
+					}},
+					Extensions: map[string]interface{}{
+						"code":         "variableNotUsed",
+						"variableName": "languageFirst",
+					},
+				},
+				{
+					Message: "Fragment LanguageFragment was defined, but not used",
+					Path:    path3,
+					Locations: []gqlerror.Location{{
+						Line:   18,
+						Column: 1,
+					}},
+					Extensions: map[string]interface{}{
+						"code":         "useAndDefineFragment",
+						"fragmentName": "LanguageFragment",
+					},
+				},
+			},
+		}
+		require.Equal(t, err, expectedErr)
+	})
+
+	t.Run("data and error", func(t *testing.T) {
+		var path ast.Path
+		json.Unmarshal([]byte(`["query GetUser","viewer","repositories","nsodes"]`), &path)
+		r := &fakeRes{}
+		err := unmarshal([]byte(gqlDataAndErr), r)
+		expectedErr := &GqlErrorList{
+			Errors: gqlerror.List{{
+				Message: "Field 'nsodes' doesn't exist on type 'RepositoryConnection'",
+				Path:    path,
+				Locations: []gqlerror.Location{{
+					Line:   6,
+					Column: 4,
+				}},
+				Extensions: map[string]interface{}{
+					"code":      "undefinedField",
+					"typeName":  "RepositoryConnection",
+					"fieldName": "nsodes",
+				},
+			}},
+		}
+		require.Equal(t, err, expectedErr)
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		r := &fakeRes{}
+		err := unmarshal([]byte(invalidJSON), r)
+		require.EqualError(t, err, "failed to decode data invalid: invalid character 'i' looking for beginning of value")
+	})
+
+	t.Run("valid data", func(t *testing.T) {
+		r := &fakeRes{}
+		err := unmarshal([]byte(validData), r)
+		require.NoError(t, err)
+
+		expected := &fakeRes{
+			Something: "some data",
+		}
+		require.Equal(t, r, expected)
+	})
+
+	t.Run("bad data format", func(t *testing.T) {
+		r := &fakeRes{}
+		err := unmarshal([]byte(withBadDataFormat), r)
+		require.EqualError(t, err, "failed to decode data into response {\"data\": \"notAndObject\"}: json: cannot unmarshal string into Go value of type client.fakeRes")
+	})
+
+	t.Run("bad data format", func(t *testing.T) {
+		r := &fakeRes{}
+		err := unmarshal([]byte(withBadErrorsFormat), r)
+		require.EqualError(t, err, "faild to parse graphql errors. Response content {\"errors\": \"bad\"} - json: cannot unmarshal string into Go struct field GqlErrorList.errors of type gqlerror.List : json: cannot unmarshal string into Go struct field GqlErrorList.errors of type gqlerror.List")
+	})
+}
+
+func TestParseResponse(t *testing.T) {
+	t.Run("single error", func(t *testing.T) {
+		r := &fakeRes{}
+		err := parseResponse([]byte(qqlSingleErr), 200, r)
+
+		expectedType := &ErrorResponse{}
+		require.IsType(t, expectedType, err)
+
+		gqlExpectedType := &gqlerror.List{}
+		require.IsType(t, gqlExpectedType, err.(*ErrorResponse).GqlErrors)
+
+		require.Nil(t, err.(*ErrorResponse).NetworkError)
+	})
+
+	t.Run("bad error format", func(t *testing.T) {
+		r := &fakeRes{}
+		err := parseResponse([]byte(withBadErrorsFormat), 200, r)
+
+		expectedType := xerrors.Errorf("%w", errors.New("some"))
+		require.IsType(t, expectedType, err)
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		r := &fakeRes{}
+		err := parseResponse([]byte(qqlSingleErr), 400, r)
+
+		expectedType := &ErrorResponse{}
+		require.IsType(t, expectedType, err)
+
+		netExpectedType := &HTTPError{}
+		require.IsType(t, netExpectedType, err.(*ErrorResponse).NetworkError)
+
+		require.Nil(t, err.(*ErrorResponse).GqlErrors)
+	})
+
+	t.Run("no error", func(t *testing.T) {
+		r := &fakeRes{}
+		err := parseResponse([]byte(validData), 200, r)
+
+		require.Nil(t, err)
+	})
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -145,7 +145,7 @@ func TestUnmarshal(t *testing.T) {
 	t.Run("bad data format", func(t *testing.T) {
 		r := &fakeRes{}
 		err := unmarshal([]byte(withBadDataFormat), r)
-		require.EqualError(t, err, "failed to decode data into response {\"data\": \"notAndObject\"}: json: cannot unmarshal string into Go value of type client.fakeRes")
+		require.EqualError(t, err, "failed to decode data into response {\"data\": \"notAndObject\"}: : : : json: cannot unmarshal string into Go value of type client.fakeRes")
 	})
 
 	t.Run("bad data format", func(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -26,10 +26,9 @@ type fakeRes struct {
 }
 
 func TestUnmarshal(t *testing.T) {
-
 	t.Run("single error", func(t *testing.T) {
 		var path ast.Path
-		json.Unmarshal([]byte(`["query GetUser","viewer","repositories","nsodes"]`), &path)
+		_ = json.Unmarshal([]byte(`["query GetUser","viewer","repositories","nsodes"]`), &path)
 		r := &fakeRes{}
 		err := unmarshal([]byte(qqlSingleErr), r)
 		expectedErr := &GqlErrorList{
@@ -52,11 +51,11 @@ func TestUnmarshal(t *testing.T) {
 
 	t.Run("multiple errors", func(t *testing.T) {
 		var path1 ast.Path
-		json.Unmarshal([]byte(`["query GetUser","viewer","repositories","nsodes"]`), &path1)
+		_ = json.Unmarshal([]byte(`["query GetUser","viewer","repositories","nsodes"]`), &path1)
 		var path2 ast.Path
-		json.Unmarshal([]byte(`["query GetUser"]`), &path2)
+		_ = json.Unmarshal([]byte(`["query GetUser"]`), &path2)
 		var path3 ast.Path
-		json.Unmarshal([]byte(`["fragment LanguageFragment"]`), &path3)
+		_ = json.Unmarshal([]byte(`["fragment LanguageFragment"]`), &path3)
 		r := &fakeRes{}
 		err := unmarshal([]byte(gqlMultipleErr), r)
 		expectedErr := &GqlErrorList{
@@ -105,7 +104,7 @@ func TestUnmarshal(t *testing.T) {
 
 	t.Run("data and error", func(t *testing.T) {
 		var path ast.Path
-		json.Unmarshal([]byte(`["query GetUser","viewer","repositories","nsodes"]`), &path)
+		_ = json.Unmarshal([]byte(`["query GetUser","viewer","repositories","nsodes"]`), &path)
 		r := &fakeRes{}
 		err := unmarshal([]byte(gqlDataAndErr), r)
 		expectedErr := &GqlErrorList{

--- a/example/github/main.go
+++ b/example/github/main.go
@@ -24,7 +24,11 @@ func main() {
 	}
 	getUser, err := githubClient.GetUser(ctx, 10, 10)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %s", err.Error())
+		if handledError, ok := err.(*client.ErrorResponse); ok {
+			fmt.Fprintf(os.Stderr, "handled error: %s\n", handledError.Error())
+		} else {
+			fmt.Fprintf(os.Stderr, "unhandled error: %s\n", err.Error())
+		}
 		os.Exit(1)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/agnivade/levenshtein v1.1.0 // indirect
 	github.com/google/go-cmp v0.5.2
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/stretchr/testify v1.4.0
 	github.com/vektah/gqlparser/v2 v2.1.0
 	golang.org/x/tools v0.0.0-20200827163409-021d7c6f1ec3 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/99designs/gqlgen v0.12.2 h1:aOdpsiCycFtCnAv8CAI1exnKrIDHMqtMzQoXeTziY4o=
-github.com/99designs/gqlgen v0.12.2/go.mod h1:7zdGo6ry9u1YBp/qlb2uxSU5Mt2jQKLcBETQiKk+Bxo=
 github.com/99designs/gqlgen v0.13.0 h1:haLTcUp3Vwp80xMVEg5KRNwzfUrgFdRmtBY8fuB8scA=
 github.com/99designs/gqlgen v0.13.0/go.mod h1:NV130r6f4tpRWuAI+zsrSdooO/eWUv+Gyyoi3rEfXIk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -24,8 +22,6 @@ github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/go-chi/chi v3.3.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/gogo/protobuf v1.0.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
-github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
@@ -59,7 +55,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
@@ -68,17 +63,12 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/shurcooL/vfsgen v0.0.0-20180121065927-ffb13db8def0/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/urfave/cli/v2 v2.1.1 h1:Qt8FeAtxE/vfdrLmR3rxR6JRE0RoVmbXu8+6kZtYU4k=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/vektah/dataloaden v0.2.1-0.20190515034641-a19b9a6e7c9e h1:+w0Zm/9gaWpEAyDlU1eKOuk5twTjAjuevXqcJJw8hrg=
 github.com/vektah/dataloaden v0.2.1-0.20190515034641-a19b9a6e7c9e/go.mod h1:/HUdMve7rvxZma+2ZELQeNh88+003LL7Pf/CZ089j8U=
-github.com/vektah/gqlparser v1.3.1 h1:8b0IcD3qZKWJQHSzynbDlrtP3IxVydZ2DZepCGofqfU=
-github.com/vektah/gqlparser v1.3.1/go.mod h1:bkVf0FX+Stjg/MHnm8mEyubuaArhNEqfQhF+OTiAL74=
-github.com/vektah/gqlparser/v2 v2.0.1 h1:xgl5abVnsd4hkN9rk65OJID9bfcLSMuTaTcZj777q1o=
-github.com/vektah/gqlparser/v2 v2.0.1/go.mod h1:SyUiHgLATUR8BiYURfTirrTcGpcE+4XkV2se04Px1Ms=
 github.com/vektah/gqlparser/v2 v2.1.0 h1:uiKJ+T5HMGGQM2kRKQ8Pxw8+Zq9qhhZhz/lieYvCMns=
 github.com/vektah/gqlparser/v2 v2.1.0/go.mod h1:SyUiHgLATUR8BiYURfTirrTcGpcE+4XkV2se04Px1Ms=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
This PR implements my vision for the error handling of a graphql response (when possible), inspired by apollo client.

## Background

Basically an operation can fail for 3 possible reasons:
1. network: when the server returns a "non OK" http code 
2. graphql: when the request is bad formatted for instance, 200 is returned and the error is described in the response
3. everything else: http code 200 but server returned data with a bad format, failed to perform the request, and so on

## Implementation

Network and graphql errors can be handled in a struct like the following, they both implements the go error interface
```go
import "github.com/vektah/gqlparser/v2/gqlerror"

type HTTPError struct {
	Code    int    `json:"code"`
	Message string `json:"message"`
}

type ErrorResponse struct {
	// populated when http status code is not OK
	NetworkError *HTTPError `json:"networkErrors"`
	// populated when http status code is OK but the server returned at least one graphql error
	GqlErrors *gqlerror.List `json:"graphqlErrors"`
}
```
Parse flow:
- If the response code is non OK, the network error will be populated with the result code and a generic message; ~~the body content won't be parsed.~~ the body will still parsed looking for a valid graphql error
- If the result code is ok, the response body is parsed in an helper struct:

```go
type response struct {
	Data   json.RawMessage `json:"data"`
	Errors json.RawMessage `json:"errors"`
}
```

- If response.Errors exists, its content is parsed into a `gqlerror.List`. If the parse fails, a generic error is returned, if succeds an ErrorResponse error type is returned

- If response.Data exists, its content is parsed into the final result struct. If the parse fails, a generic error is returned

## How to check the error

The error can be checked with a simple type assertion:

```go
getUser, err := githubClient.GetUser(ctx, 10, 10)
if err != nil {
	if handledError, ok := err.(*client.ErrorResponse); ok {
		fmt.Fprintf(os.Stderr, "handled error: %s\n", handledError.Error())
	} else {
		fmt.Fprintf(os.Stderr, "unhandled error: %s\n", err.Error())
	}
	os.Exit(1)
}
```

This PR resolves #21 


**EDIT: ** since some servers return a formatted and valid graphql error even if the http code is "non OK", the response body is always parsed, looking for graphql errors 

What do you think? 