### PR TITLE
Fixed to load config file like gqlgen

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -26,7 +26,9 @@ type fakeRes struct {
 }
 
 func TestUnmarshal(t *testing.T) {
+	t.Parallel()
 	t.Run("single error", func(t *testing.T) {
+		t.Parallel()
 		var path ast.Path
 		_ = json.Unmarshal([]byte(`["query GetUser","viewer","repositories","nsodes"]`), &path)
 		r := &fakeRes{}
@@ -50,6 +52,7 @@ func TestUnmarshal(t *testing.T) {
 	})
 
 	t.Run("multiple errors", func(t *testing.T) {
+		t.Parallel()
 		var path1 ast.Path
 		_ = json.Unmarshal([]byte(`["query GetUser","viewer","repositories","nsodes"]`), &path1)
 		var path2 ast.Path
@@ -103,6 +106,7 @@ func TestUnmarshal(t *testing.T) {
 	})
 
 	t.Run("data and error", func(t *testing.T) {
+		t.Parallel()
 		var path ast.Path
 		_ = json.Unmarshal([]byte(`["query GetUser","viewer","repositories","nsodes"]`), &path)
 		r := &fakeRes{}
@@ -126,12 +130,14 @@ func TestUnmarshal(t *testing.T) {
 	})
 
 	t.Run("invalid json", func(t *testing.T) {
+		t.Parallel()
 		r := &fakeRes{}
 		err := unmarshal([]byte(invalidJSON), r)
 		require.EqualError(t, err, "failed to decode data invalid: invalid character 'i' looking for beginning of value")
 	})
 
 	t.Run("valid data", func(t *testing.T) {
+		t.Parallel()
 		r := &fakeRes{}
 		err := unmarshal([]byte(validData), r)
 		require.NoError(t, err)
@@ -143,12 +149,14 @@ func TestUnmarshal(t *testing.T) {
 	})
 
 	t.Run("bad data format", func(t *testing.T) {
+		t.Parallel()
 		r := &fakeRes{}
 		err := unmarshal([]byte(withBadDataFormat), r)
 		require.EqualError(t, err, "failed to decode data into response {\"data\": \"notAndObject\"}: : : : json: cannot unmarshal string into Go value of type client.fakeRes")
 	})
 
 	t.Run("bad data format", func(t *testing.T) {
+		t.Parallel()
 		r := &fakeRes{}
 		err := unmarshal([]byte(withBadErrorsFormat), r)
 		require.EqualError(t, err, "faild to parse graphql errors. Response content {\"errors\": \"bad\"} - json: cannot unmarshal string into Go struct field GqlErrorList.errors of type gqlerror.List : json: cannot unmarshal string into Go struct field GqlErrorList.errors of type gqlerror.List")
@@ -156,7 +164,9 @@ func TestUnmarshal(t *testing.T) {
 }
 
 func TestParseResponse(t *testing.T) {
+	t.Parallel()
 	t.Run("single error", func(t *testing.T) {
+		t.Parallel()
 		r := &fakeRes{}
 		err := parseResponse([]byte(qqlSingleErr), 200, r)
 
@@ -170,6 +180,7 @@ func TestParseResponse(t *testing.T) {
 	})
 
 	t.Run("bad error format", func(t *testing.T) {
+		t.Parallel()
 		r := &fakeRes{}
 		err := parseResponse([]byte(withBadErrorsFormat), 200, r)
 
@@ -178,6 +189,7 @@ func TestParseResponse(t *testing.T) {
 	})
 
 	t.Run("network error with valid gql error response", func(t *testing.T) {
+		t.Parallel()
 		r := &fakeRes{}
 		err := parseResponse([]byte(qqlSingleErr), 400, r)
 
@@ -192,6 +204,7 @@ func TestParseResponse(t *testing.T) {
 	})
 
 	t.Run("network error with not valid gql error response", func(t *testing.T) {
+		t.Parallel()
 		r := &fakeRes{}
 		err := parseResponse([]byte(invalidJSON), 500, r)
 
@@ -205,6 +218,7 @@ func TestParseResponse(t *testing.T) {
 	})
 
 	t.Run("no error", func(t *testing.T) {
+		t.Parallel()
 		r := &fakeRes{}
 		err := parseResponse([]byte(validData), 200, r)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,32 +8,39 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
+	t.Parallel()
 	t.Run("config does not exist", func(t *testing.T) {
+		t.Parallel()
 		_, err := LoadConfig("doesnotexist.yml")
 		require.Error(t, err)
 	})
 
 	t.Run("malformed config", func(t *testing.T) {
+		t.Parallel()
 		_, err := LoadConfig("testdata/cfg/malformedconfig.yml")
 		require.EqualError(t, err, "unable to parse config: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `asdf` into config.Config")
 	})
 
 	t.Run("'schema' and 'endpoint' both specified", func(t *testing.T) {
+		t.Parallel()
 		_, err := LoadConfig("testdata/cfg/schema_endpoint.yml")
 		require.EqualError(t, err, "'schema' and 'endpoint' both specified. Use schema to load from a local file, use endpoint to load from a remote server (using introspection)")
 	})
 
 	t.Run("neither 'schema' nor 'endpoint' specified", func(t *testing.T) {
+		t.Parallel()
 		_, err := LoadConfig("testdata/cfg/no_source.yml")
 		require.EqualError(t, err, "neither 'schema' nor 'endpoint' specified. Use schema to load from a local file, use endpoint to load from a remote server (using introspection)")
 	})
 
 	t.Run("unknown keys", func(t *testing.T) {
+		t.Parallel()
 		_, err := LoadConfig("testdata/cfg/unknownkeys.yml")
 		require.EqualError(t, err, "unable to parse config: yaml: unmarshal errors:\n  line 3: field unknown not found in type config.Config")
 	})
 
 	t.Run("globbed filenames", func(t *testing.T) {
+		t.Parallel()
 		c, err := LoadConfig("testdata/cfg/glob.yml")
 		require.NoError(t, err)
 
@@ -47,6 +54,7 @@ func TestLoadConfig(t *testing.T) {
 	})
 
 	t.Run("unwalkable path", func(t *testing.T) {
+		t.Parallel()
 		_, err := LoadConfig("testdata/cfg/unwalkable.yml")
 		if runtime.GOOS == "windows" {
 			require.EqualError(t, err, "failed to walk schema at root not_walkable/: CreateFile not_walkable/: The system cannot find the file specified.")
@@ -56,6 +64,7 @@ func TestLoadConfig(t *testing.T) {
 	})
 
 	t.Run("generate", func(t *testing.T) {
+		t.Parallel()
 		c, err := LoadConfig("testdata/cfg/generate.yml")
 		require.NoError(t, err)
 		require.Equal(t, c.Generate.Suffix.Mutation, "Bar")

--- a/graphqljson/graphql_test.go
+++ b/graphqljson/graphql_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestUnmarshalGraphQL(t *testing.T) {
+	t.Parallel()
 	/*
 		query {
 			me {
@@ -42,6 +43,7 @@ func TestUnmarshalGraphQL(t *testing.T) {
 }
 
 func TestUnmarshalGraphQL_graphqlTag(t *testing.T) {
+	t.Parallel()
 	type query struct {
 		Foo string `graphql:"baz"`
 	}
@@ -61,6 +63,7 @@ func TestUnmarshalGraphQL_graphqlTag(t *testing.T) {
 }
 
 func TestUnmarshalGraphQL_jsonTag(t *testing.T) {
+	t.Parallel()
 	type query struct {
 		Foo string `json:"baz"`
 	}
@@ -80,6 +83,7 @@ func TestUnmarshalGraphQL_jsonTag(t *testing.T) {
 }
 
 func TestUnmarshalGraphQL_array(t *testing.T) {
+	t.Parallel()
 	type query struct {
 		Foo []string
 		Bar []string
@@ -110,6 +114,7 @@ func TestUnmarshalGraphQL_array(t *testing.T) {
 // When unmarshaling into an array, its initial value should be overwritten
 // (rather than appended to).
 func TestUnmarshalGraphQL_arrayReset(t *testing.T) {
+	t.Parallel()
 	got := []string{"initial"}
 	err := graphqljson.UnmarshalData([]byte(`["bar", "baz"]`), &got)
 	if err != nil {
@@ -122,6 +127,7 @@ func TestUnmarshalGraphQL_arrayReset(t *testing.T) {
 }
 
 func TestUnmarshalGraphQL_objectArray(t *testing.T) {
+	t.Parallel()
 	type query struct {
 		Foo []struct {
 			Name string
@@ -149,6 +155,7 @@ func TestUnmarshalGraphQL_objectArray(t *testing.T) {
 }
 
 func TestUnmarshalGraphQL_pointer(t *testing.T) {
+	t.Parallel()
 	type query struct {
 		Foo *string
 		Bar *string
@@ -173,6 +180,7 @@ func TestUnmarshalGraphQL_pointer(t *testing.T) {
 }
 
 func TestUnmarshalGraphQL_objectPointerArray(t *testing.T) {
+	t.Parallel()
 	type query struct {
 		Foo []*struct {
 			Name string
@@ -202,6 +210,7 @@ func TestUnmarshalGraphQL_objectPointerArray(t *testing.T) {
 }
 
 func TestUnmarshalGraphQL_pointerWithInlineFragment(t *testing.T) {
+	t.Parallel()
 	type actor struct {
 		User struct {
 			DatabaseID uint64
@@ -242,6 +251,7 @@ func TestUnmarshalGraphQL_pointerWithInlineFragment(t *testing.T) {
 }
 
 func TestUnmarshalGraphQL_unexportedField(t *testing.T) {
+	t.Parallel()
 	type query struct {
 		foo string
 	}
@@ -257,6 +267,7 @@ func TestUnmarshalGraphQL_unexportedField(t *testing.T) {
 }
 
 func TestUnmarshalGraphQL_multipleValues(t *testing.T) {
+	t.Parallel()
 	type query struct {
 		Foo string
 	}
@@ -270,6 +281,7 @@ func TestUnmarshalGraphQL_multipleValues(t *testing.T) {
 }
 
 func TestUnmarshalGraphQL_union(t *testing.T) {
+	t.Parallel()
 	/*
 		{
 			__typename
@@ -332,6 +344,7 @@ func TestUnmarshalGraphQL_union(t *testing.T) {
 }
 
 func TestUnmarshalGraphQL_union2(t *testing.T) {
+	t.Parallel()
 	type SubscriptionItemFragment struct {
 		ID string
 	}
@@ -380,6 +393,7 @@ func TestUnmarshalGraphQL_union2(t *testing.T) {
 
 // Issue https://github.com/shurcooL/githubv4/issues/18.
 func TestUnmarshalGraphQL_arrayInsideInlineFragment(t *testing.T) {
+	t.Parallel()
 	/*
 		query {
 			search(type: ISSUE, first: 1, query: "type:pr repo:owner/name") {

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	cfg, err := config.LoadConfig(".gqlgenc.yml")
+	cfg, err := config.LoadConfigFromDefaultLocations()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%+v", err.Error())
 		os.Exit(2)


### PR DESCRIPTION
Now, Don't generate for `go generate`. the following code  join gqlgenc.
source: https://github.com/99designs/gqlgen/blob/862762c77bae8b5f119c401d037358cfaf33fa52/codegen/config/config.go#L71-L84