### PR TITLE
Fix for #39

### DIFF
--- a/config/testdata/remote/response_invalid_schema.json
+++ b/config/testdata/remote/response_invalid_schema.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": {
+        "name": "Query"
+      },
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Query"
+        }
+      ]
+    }
+  }
+}

--- a/config/testdata/remote/response_ok.json
+++ b/config/testdata/remote/response_ok.json
@@ -1,0 +1,47 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": {
+        "name": "Query"
+      },
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "fields": [
+            {
+              "name": "test",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The `Position` must be defined on the various `ast.XXX` elements otherwise when the schema validation fails, a nil pointer error is raised because most of the `gqlparser` error construction function expects the `Position` field to be set.

To overcome the problem, this PR uses a single shared & cached position object for all `Position` fields. A second approach will use a single position object for the active parse action.

The test that have been added acts more as a sanity check than a full coverage.