### PR TITLE
Fix #39

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -259,7 +259,7 @@ func (c *Config) loadRemoteSchema(ctx context.Context) (*ast.Schema, error) {
 		return nil, xerrors.Errorf("introspection query failed: %w", err)
 	}
 
-	schema, err := validator.ValidateSchemaDocument(introspection.ParseIntrospectionQuery(res))
+	schema, err := validator.ValidateSchemaDocument(introspection.ParseIntrospectionQuery(c.Endpoint.URL, res))
 	if err != nil {
 		return nil, xerrors.Errorf("validation error: %w", err)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,9 +1,16 @@
 package config
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"runtime"
 	"testing"
 
+	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,4 +79,86 @@ func TestLoadConfig(t *testing.T) {
 		require.Equal(t, c.Generate.Prefix.Mutation, "Hoge")
 		require.Equal(t, c.Generate.Prefix.Query, "Data")
 	})
+}
+
+func TestLoadConfig_LoadSchema(t *testing.T) {
+	t.Parallel()
+
+	t.Run("correct schema", func(t *testing.T) {
+		t.Parallel()
+
+		mockServer, closeServer := newMockRemoteServer(t, responseFromFile("testdata/remote/response_ok.json"))
+		defer closeServer()
+
+		config := &Config{
+			GQLConfig: &config.Config{},
+			Endpoint: &EndPointConfig{
+				URL: mockServer.URL,
+			},
+		}
+
+		err := config.LoadSchema(context.Background())
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid schema", func(t *testing.T) {
+		t.Parallel()
+
+		mockServer, closeServer := newMockRemoteServer(t, responseFromFile("testdata/remote/response_invalid_schema.json"))
+		defer closeServer()
+
+		config := &Config{
+			GQLConfig: &config.Config{},
+			Endpoint: &EndPointConfig{
+				URL: mockServer.URL,
+			},
+		}
+
+		err := config.LoadSchema(context.Background())
+		require.Equal(t, fmt.Sprintf("load remote schema failed: validation error: %s:0: OBJECT must define one or more fields.", mockServer.URL), err.Error())
+	})
+}
+
+type mockRemoteServer struct {
+	*httptest.Server
+	body []byte
+}
+
+func newMockRemoteServer(t *testing.T, response interface{}) (mock *mockRemoteServer, closeServer func()) {
+	t.Helper()
+
+	mock = &mockRemoteServer{
+		Server: httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			var err error
+			mock.body, err = ioutil.ReadAll(req.Body)
+			require.NoError(t, err)
+
+			var responseBody []byte
+			switch v := response.(type) {
+			case json.RawMessage:
+				responseBody = v
+			case responseFromFile:
+				responseBody = v.load(t)
+			default:
+				responseBody, err = json.Marshal(response)
+				require.NoError(t, err)
+			}
+
+			_, err = rw.Write(responseBody)
+			require.NoError(t, err)
+		})),
+	}
+
+	return mock, func() { mock.Close() }
+}
+
+type responseFromFile string
+
+func (f responseFromFile) load(t *testing.T) []byte {
+	t.Helper()
+
+	content, err := ioutil.ReadFile(string(f))
+	require.NoError(t, err)
+
+	return content
 }

--- a/config/testdata/remote/response_invalid_schema.json
+++ b/config/testdata/remote/response_invalid_schema.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": {
+        "name": "Query"
+      },
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Query"
+        }
+      ]
+    }
+  }
+}

--- a/config/testdata/remote/response_ok.json
+++ b/config/testdata/remote/response_ok.json
@@ -1,0 +1,47 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": {
+        "name": "Query"
+      },
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "fields": [
+            {
+              "name": "test",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/introspection/parse.go
+++ b/introspection/parse.go
@@ -6,61 +6,84 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
-func ParseIntrospectionQuery(query Query) *ast.SchemaDocument {
+func ParseIntrospectionQuery(url string, query Query) *ast.SchemaDocument {
+	parser := parser{
+		sharedPosition: &ast.Position{Src: &ast.Source{
+			Name:    "remote",
+			BuiltIn: false,
+		}},
+	}
+
+	if url != "" {
+		parser.sharedPosition.Src.Name = url
+	}
+
+	return parser.parseIntrospectionQuery(query)
+}
+
+type parser struct {
+	sharedPosition *ast.Position
+}
+
+func (p parser) parseIntrospectionQuery(query Query) *ast.SchemaDocument {
 	var doc ast.SchemaDocument
 	typeMap := query.Schema.Types.NameMap()
 
-	doc.Schema = append(doc.Schema, parseSchemaDefinition(query, typeMap))
+	doc.Schema = append(doc.Schema, p.parseSchemaDefinition(query, typeMap))
+	doc.Position = p.sharedPosition
 
 	for _, typeVale := range typeMap {
-		doc.Definitions = append(doc.Definitions, parseTypeSystemDefinition(typeVale))
+		doc.Definitions = append(doc.Definitions, p.parseTypeSystemDefinition(typeVale))
 	}
 
 	for _, directiveValue := range query.Schema.Directives {
-		doc.Directives = append(doc.Directives, parseDirectiveDefinition(directiveValue))
+		doc.Directives = append(doc.Directives, p.parseDirectiveDefinition(directiveValue))
 	}
 
 	return &doc
 }
 
-func parseSchemaDefinition(query Query, typeMap map[string]*FullType) *ast.SchemaDefinition {
+func (p parser) parseSchemaDefinition(query Query, typeMap map[string]*FullType) *ast.SchemaDefinition {
 	def := ast.SchemaDefinition{}
+	def.Position = p.sharedPosition
 
 	if query.Schema.QueryType.Name != nil {
 		def.OperationTypes = append(def.OperationTypes,
-			parseOperationTypeDefinitionForQuery(typeMap[*query.Schema.QueryType.Name]),
+			p.parseOperationTypeDefinitionForQuery(typeMap[*query.Schema.QueryType.Name]),
 		)
 	}
 
 	if query.Schema.MutationType != nil {
 		def.OperationTypes = append(def.OperationTypes,
-			parseOperationTypeDefinitionForMutation(typeMap[*query.Schema.MutationType.Name]),
+			p.parseOperationTypeDefinitionForMutation(typeMap[*query.Schema.MutationType.Name]),
 		)
 	}
 
 	return &def
 }
 
-func parseOperationTypeDefinitionForQuery(fullType *FullType) *ast.OperationTypeDefinition {
+func (p parser) parseOperationTypeDefinitionForQuery(fullType *FullType) *ast.OperationTypeDefinition {
 	var op ast.OperationTypeDefinition
 	op.Operation = ast.Query
 	op.Type = *fullType.Name
+	op.Position = p.sharedPosition
 
 	return &op
 }
 
-func parseOperationTypeDefinitionForMutation(fullType *FullType) *ast.OperationTypeDefinition {
+func (p parser) parseOperationTypeDefinitionForMutation(fullType *FullType) *ast.OperationTypeDefinition {
 	var op ast.OperationTypeDefinition
 	op.Operation = ast.Mutation
 	op.Type = *fullType.Name
+	op.Position = p.sharedPosition
 
 	return &op
 }
 
-func parseDirectiveDefinition(directiveValue *DirectiveType) *ast.DirectiveDefinition {
+func (p parser) parseDirectiveDefinition(directiveValue *DirectiveType) *ast.DirectiveDefinition {
 	args := make(ast.ArgumentDefinitionList, 0, len(directiveValue.Args))
 	for _, arg := range directiveValue.Args {
-		argumentDefinition := buildInputValue(arg)
+		argumentDefinition := p.buildInputValue(arg)
 		args = append(args, argumentDefinition)
 	}
 	locations := make([]ast.DirectiveLocation, 0, len(directiveValue.Locations))
@@ -73,16 +96,17 @@ func parseDirectiveDefinition(directiveValue *DirectiveType) *ast.DirectiveDefin
 		Name:        directiveValue.Name,
 		Arguments:   args,
 		Locations:   locations,
+		Position:    p.sharedPosition,
 	}
 }
 
-func parseObjectFields(typeVale *FullType) ast.FieldList {
+func (p parser) parseObjectFields(typeVale *FullType) ast.FieldList {
 	fieldList := make(ast.FieldList, 0, len(typeVale.Fields))
 	for _, field := range typeVale.Fields {
-		typ := getType(&field.Type)
+		typ := p.getType(&field.Type)
 		args := make(ast.ArgumentDefinitionList, 0, len(field.Args))
 		for _, arg := range field.Args {
-			argumentDefinition := buildInputValue(arg)
+			argumentDefinition := p.buildInputValue(arg)
 			args = append(args, argumentDefinition)
 		}
 
@@ -91,6 +115,7 @@ func parseObjectFields(typeVale *FullType) ast.FieldList {
 			Name:        field.Name,
 			Arguments:   args,
 			Type:        typ,
+			Position:    p.sharedPosition,
 		}
 		fieldList = append(fieldList, fieldDefinition)
 	}
@@ -98,14 +123,15 @@ func parseObjectFields(typeVale *FullType) ast.FieldList {
 	return fieldList
 }
 
-func parseInputObjectFields(typeVale *FullType) ast.FieldList {
+func (p parser) parseInputObjectFields(typeVale *FullType) ast.FieldList {
 	fieldList := make(ast.FieldList, 0, len(typeVale.InputFields))
 	for _, field := range typeVale.InputFields {
-		typ := getType(&field.Type)
+		typ := p.getType(&field.Type)
 		fieldDefinition := &ast.FieldDefinition{
 			Description: pointerString(field.Description),
 			Name:        field.Name,
 			Type:        typ,
+			Position:    p.sharedPosition,
 		}
 		fieldList = append(fieldList, fieldDefinition)
 	}
@@ -113,8 +139,8 @@ func parseInputObjectFields(typeVale *FullType) ast.FieldList {
 	return fieldList
 }
 
-func parseObjectTypeDefinition(typeVale *FullType) *ast.Definition {
-	fieldList := parseObjectFields(typeVale)
+func (p parser) parseObjectTypeDefinition(typeVale *FullType) *ast.Definition {
+	fieldList := p.parseObjectFields(typeVale)
 	interfaces := make([]string, 0, len(typeVale.Interfaces))
 	for _, intf := range typeVale.Interfaces {
 		interfaces = append(interfaces, pointerString(intf.Name))
@@ -125,6 +151,7 @@ func parseObjectTypeDefinition(typeVale *FullType) *ast.Definition {
 		enumValue := &ast.EnumValueDefinition{
 			Description: pointerString(enum.Description),
 			Name:        enum.Name,
+			Position:    p.sharedPosition,
 		}
 		enums = append(enums, enumValue)
 	}
@@ -136,13 +163,13 @@ func parseObjectTypeDefinition(typeVale *FullType) *ast.Definition {
 		Interfaces:  interfaces,
 		Fields:      fieldList,
 		EnumValues:  enums,
-		Position:    nil,
+		Position:    p.sharedPosition,
 		BuiltIn:     true,
 	}
 }
 
-func parseInterfaceTypeDefinition(typeVale *FullType) *ast.Definition {
-	fieldList := parseObjectFields(typeVale)
+func (p parser) parseInterfaceTypeDefinition(typeVale *FullType) *ast.Definition {
+	fieldList := p.parseObjectFields(typeVale)
 	interfaces := make([]string, 0, len(typeVale.Interfaces))
 	for _, intf := range typeVale.Interfaces {
 		interfaces = append(interfaces, pointerString(intf.Name))
@@ -154,13 +181,13 @@ func parseInterfaceTypeDefinition(typeVale *FullType) *ast.Definition {
 		Name:        pointerString(typeVale.Name),
 		Interfaces:  interfaces,
 		Fields:      fieldList,
-		Position:    nil,
+		Position:    p.sharedPosition,
 		BuiltIn:     true,
 	}
 }
 
-func parseInputObjectTypeDefinition(typeVale *FullType) *ast.Definition {
-	fieldList := parseInputObjectFields(typeVale)
+func (p parser) parseInputObjectTypeDefinition(typeVale *FullType) *ast.Definition {
+	fieldList := p.parseInputObjectFields(typeVale)
 	interfaces := make([]string, 0, len(typeVale.Interfaces))
 	for _, intf := range typeVale.Interfaces {
 		interfaces = append(interfaces, pointerString(intf.Name))
@@ -172,12 +199,12 @@ func parseInputObjectTypeDefinition(typeVale *FullType) *ast.Definition {
 		Name:        pointerString(typeVale.Name),
 		Interfaces:  interfaces,
 		Fields:      fieldList,
-		Position:    nil,
+		Position:    p.sharedPosition,
 		BuiltIn:     true,
 	}
 }
 
-func parseUnionTypeDefinition(typeVale *FullType) *ast.Definition {
+func (p parser) parseUnionTypeDefinition(typeVale *FullType) *ast.Definition {
 	unions := make([]string, 0, len(typeVale.PossibleTypes))
 	for _, unionValue := range typeVale.PossibleTypes {
 		unions = append(unions, *unionValue.Name)
@@ -188,17 +215,18 @@ func parseUnionTypeDefinition(typeVale *FullType) *ast.Definition {
 		Description: pointerString(typeVale.Description),
 		Name:        pointerString(typeVale.Name),
 		Types:       unions,
-		Position:    nil,
+		Position:    p.sharedPosition,
 		BuiltIn:     true,
 	}
 }
 
-func parseEnumTypeDefinition(typeVale *FullType) *ast.Definition {
+func (p parser) parseEnumTypeDefinition(typeVale *FullType) *ast.Definition {
 	enums := make(ast.EnumValueList, 0, len(typeVale.EnumValues))
 	for _, enum := range typeVale.EnumValues {
 		enumValue := &ast.EnumValueDefinition{
 			Description: pointerString(enum.Description),
 			Name:        enum.Name,
+			Position:    p.sharedPosition,
 		}
 		enums = append(enums, enumValue)
 	}
@@ -208,35 +236,35 @@ func parseEnumTypeDefinition(typeVale *FullType) *ast.Definition {
 		Description: pointerString(typeVale.Description),
 		Name:        pointerString(typeVale.Name),
 		EnumValues:  enums,
-		Position:    nil,
+		Position:    p.sharedPosition,
 		BuiltIn:     true,
 	}
 }
 
-func parseScalarTypeExtension(typeVale *FullType) *ast.Definition {
+func (p parser) parseScalarTypeExtension(typeVale *FullType) *ast.Definition {
 	return &ast.Definition{
 		Kind:        ast.Scalar,
 		Description: pointerString(typeVale.Description),
 		Name:        pointerString(typeVale.Name),
-		Position:    nil,
+		Position:    p.sharedPosition,
 		BuiltIn:     true,
 	}
 }
 
-func parseTypeSystemDefinition(typeVale *FullType) *ast.Definition {
+func (p parser) parseTypeSystemDefinition(typeVale *FullType) *ast.Definition {
 	switch typeVale.Kind {
 	case TypeKindScalar:
-		return parseScalarTypeExtension(typeVale)
+		return p.parseScalarTypeExtension(typeVale)
 	case TypeKindInterface:
-		return parseInterfaceTypeDefinition(typeVale)
+		return p.parseInterfaceTypeDefinition(typeVale)
 	case TypeKindEnum:
-		return parseEnumTypeDefinition(typeVale)
+		return p.parseEnumTypeDefinition(typeVale)
 	case TypeKindUnion:
-		return parseUnionTypeDefinition(typeVale)
+		return p.parseUnionTypeDefinition(typeVale)
 	case TypeKindObject:
-		return parseObjectTypeDefinition(typeVale)
+		return p.parseObjectTypeDefinition(typeVale)
 	case TypeKindInputObject:
-		return parseInputObjectTypeDefinition(typeVale)
+		return p.parseInputObjectTypeDefinition(typeVale)
 	case TypeKindList, TypeKindNonNull:
 		panic(fmt.Sprintf("not match Kind: %s", typeVale.Kind))
 	}
@@ -244,22 +272,15 @@ func parseTypeSystemDefinition(typeVale *FullType) *ast.Definition {
 	panic(fmt.Sprintf("not match Kind: %s", typeVale.Kind))
 }
 
-func pointerString(s *string) string {
-	if s == nil {
-		return ""
-	}
-
-	return *s
-}
-
-func buildInputValue(input *InputValue) *ast.ArgumentDefinition {
-	typ := getType(&input.Type)
+func (p parser) buildInputValue(input *InputValue) *ast.ArgumentDefinition {
+	typ := p.getType(&input.Type)
 
 	var defaultValue *ast.Value
 	if input.DefaultValue != nil {
 		defaultValue = &ast.Value{
-			Raw:  pointerString(input.DefaultValue),
-			Kind: ast.Variable,
+			Raw:      pointerString(input.DefaultValue),
+			Kind:     ast.Variable,
+			Position: p.sharedPosition,
 		}
 	}
 
@@ -268,17 +289,18 @@ func buildInputValue(input *InputValue) *ast.ArgumentDefinition {
 		Name:         input.Name,
 		DefaultValue: defaultValue,
 		Type:         typ,
+		Position:     p.sharedPosition,
 	}
 }
 
-func getType(typeRef *TypeRef) *ast.Type {
+func (p parser) getType(typeRef *TypeRef) *ast.Type {
 	if typeRef.Kind == TypeKindList {
 		itemRef := typeRef.OfType
 		if itemRef == nil {
 			panic("Decorated type deeper than introspection query.")
 		}
 
-		return ast.ListType(getType(itemRef), nil)
+		return ast.ListType(p.getType(itemRef), p.sharedPosition)
 	}
 
 	if typeRef.Kind == TypeKindNonNull {
@@ -286,11 +308,19 @@ func getType(typeRef *TypeRef) *ast.Type {
 		if nullableRef == nil {
 			panic("Decorated type deeper than introspection query.")
 		}
-		nullableType := getType(nullableRef)
+		nullableType := p.getType(nullableRef)
 		nullableType.NonNull = true
 
 		return nullableType
 	}
 
-	return ast.NamedType(pointerString(typeRef.Name), nil)
+	return ast.NamedType(pointerString(typeRef.Name), p.sharedPosition)
+}
+
+func pointerString(s *string) string {
+	if s == nil {
+		return ""
+	}
+
+	return *s
 }

--- a/introspection/parser_test.go
+++ b/introspection/parser_test.go
@@ -27,12 +27,12 @@ func TestParseIntrospectionQuery_Parse(t *testing.T) {
 
 			if test.expectedErr == nil {
 				require.NotPanics(t, func() {
-					ast := ParseIntrospectionQuery(query)
+					ast := ParseIntrospectionQuery("test", query)
 					require.NotNil(t, ast)
 				})
 			} else {
 				require.PanicsWithValue(t, test.expectedErr, func() {
-					ast := ParseIntrospectionQuery(query)
+					ast := ParseIntrospectionQuery("test", query)
 					require.Nil(t, ast)
 				})
 			}


### PR DESCRIPTION
The Position must be defined on the various ast.XXX elements otherwise when the schema validation fails, a nil pointer error is raised because most of the gqlparser error construction function expects the Position field to be set.

To overcome the problem, this PR uses a single shared & cached position object for all Position fields. A second approach will use a single position object for the active parse action.

The test that have been added acts more as a sanity check than a full coverage.