### PR TITLE
Use valid gqlgenc file in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ query:
   - "./query/*.graphql" # Where are all the query files located?
 ```
 
-Execute the following command on same directory for .gqlgenc.yaml
+Execute the following command on same directory for .gqlgenc.yml
 
 ```shell script
 gqlgenc


### PR DESCRIPTION
Currently, these are the valid filenames:

![image](https://user-images.githubusercontent.com/6392429/108781585-1e2fce80-7538-11eb-81da-491c16a2a2db.png)


This updates the documentation so the readme uses one of them