### PR TITLE
Proposition to change the generated document variable's name suffix to `Document` instead of `Query`

### DIFF
--- a/clientgen/template.gotpl
+++ b/clientgen/template.gotpl
@@ -37,7 +37,7 @@ type {{ .Query.Name | go }} {{ .Query.Type | ref }}
 {{- end }}
 
 {{- range $model := .Operation}}
-const {{ $model.Name|go }}Query = `{{ $model.Operation }}`
+const {{ $model.Name|go }}Op = `{{ $model.Operation }}`
 
 func (c *Client) {{ $model.Name | go }} (ctx context.Context{{- range $arg := .Args }}, {{ $arg.Variable | goPrivate }} {{ $arg.Type | ref }} {{- end }}, httpRequestOptions ...client.HTTPRequestOption) (*{{ $model.ResponseStructName | go }}, error) {
 	vars := map[string]interface{}{
@@ -47,7 +47,7 @@ func (c *Client) {{ $model.Name | go }} (ctx context.Context{{- range $arg := .A
 	}
 
     var res {{ $model.ResponseStructName | go }}
-    if err := c.Client.Post(ctx, "{{ $model.Name }}", {{ $model.Name|go }}Query, &res, vars, httpRequestOptions...); err != nil {
+    if err := c.Client.Post(ctx, "{{ $model.Name }}", {{ $model.Name|go }}Op, &res, vars, httpRequestOptions...); err != nil {
         return nil, err
     }
 

--- a/clientgen/template.gotpl
+++ b/clientgen/template.gotpl
@@ -37,7 +37,7 @@ type {{ .Query.Name | go }} {{ .Query.Type | ref }}
 {{- end }}
 
 {{- range $model := .Operation}}
-const {{ $model.Name|go }}Op = `{{ $model.Operation }}`
+const {{ $model.Name|go }}Document = `{{ $model.Operation }}`
 
 func (c *Client) {{ $model.Name | go }} (ctx context.Context{{- range $arg := .Args }}, {{ $arg.Variable | goPrivate }} {{ $arg.Type | ref }} {{- end }}, httpRequestOptions ...client.HTTPRequestOption) (*{{ $model.ResponseStructName | go }}, error) {
 	vars := map[string]interface{}{
@@ -47,7 +47,7 @@ func (c *Client) {{ $model.Name | go }} (ctx context.Context{{- range $arg := .A
 	}
 
     var res {{ $model.ResponseStructName | go }}
-    if err := c.Client.Post(ctx, "{{ $model.Name }}", {{ $model.Name|go }}Op, &res, vars, httpRequestOptions...); err != nil {
+    if err := c.Client.Post(ctx, "{{ $model.Name }}", {{ $model.Name|go }}Document, &res, vars, httpRequestOptions...); err != nil {
         return nil, err
     }
 

--- a/clientgenv2/template.gotpl
+++ b/clientgenv2/template.gotpl
@@ -35,7 +35,7 @@ type {{ .Mutation.Name | go }} {{ .Mutation.Type | ref }}
 {{- end }}
 
 {{- range $model := .Operation}}
-	const {{ $model.Name|go }}Query = `{{ $model.Operation }}`
+	const {{ $model.Name|go }}Document = `{{ $model.Operation }}`
 
 	func (c *Client) {{ $model.Name|go }} (ctx context.Context{{- range $arg := .Args }}, {{ $arg.Variable | goPrivate }} {{ $arg.Type | ref }} {{- end }}, interceptors ...clientv2.RequestInterceptor) (*{{ $model.ResponseStructName | go }}, error) {
 	vars := map[string]interface{}{
@@ -45,7 +45,7 @@ type {{ .Mutation.Name | go }} {{ .Mutation.Type | ref }}
 	}
 
 	var res {{ $model.ResponseStructName | go }}
-	if err := c.Client.Post(ctx, "{{ $model.Name|go }}", {{ $model.Name|go }}Query, &res, vars, interceptors...); err != nil {
+	if err := c.Client.Post(ctx, "{{ $model.Name|go }}", {{ $model.Name|go }}Document, &res, vars, interceptors...); err != nil {
 	return nil, err
 	}
 


### PR DESCRIPTION
The `Query` suffix is not ideal in my opinion since:
- It's weird to use `Query` suffix when the actual document type is a Mutation, and gives weird usage like `updateUser(gql.UpdateUserQuery)`.
- A Query naming suffix in the generate config is something that could prove to be wanted, lead to confusion with the "document"

A such, I propose to change the suffix from `Query` to `Op`. I thought about using `Document`
or `Doc` but `Op` felt more aligned with the fact that we range over a list of operations.

This can be seen as a backward breaking change since upon a re-run of the gqlgenc binary,
some variables will not have the same name.

Alternatives:
- Keep `Query` as the default suffix but allow a rename through the `GenerateConfig` object.
- Perform the necessary change but generate also and alias ending in `Query`.
- Switch to `Op` as the default suffix but allow a rename through the `GenerateConfig` object to ease transition.
- Switch to `Op` directly without further changes.

Let me know what you think.