### PR TITLE
Allow user override of Operation type

### DIFF
--- a/clientgenv2/source.go
+++ b/clientgenv2/source.go
@@ -135,7 +135,7 @@ func (s *Source) OperationResponses() ([]*OperationResponse, error) {
 		responseFields := s.sourceGenerator.NewResponseFields(operation.SelectionSet)
 		name := getResponseStructName(operation, s.generateConfig)
 		if s.sourceGenerator.cfg.Models.Exists(name) {
-			return nil, xerrors.New(fmt.Sprintf("%s is duplicated", name))
+			continue
 		}
 		operationResponse = append(operationResponse, &OperationResponse{
 			Name: name,


### PR DESCRIPTION
This would allow users to provide their own types in `models` to be used as response types (basically just prevents it from being generated)

Should we remove the `error` from the signature, or add an exception for that lint error ?