### PR TITLE
Pass properly formatted go type when adding model to source generator config

### DIFF
--- a/clientgen/source.go
+++ b/clientgen/source.go
@@ -52,7 +52,7 @@ func (s *Source) Fragments() ([]*Fragment, error) {
 		name := fragment.Name
 		s.sourceGenerator.cfg.Models.Add(
 			name,
-			fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg(), templates.ToGo(name)),
+			fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg().Path(), templates.ToGo(name)),
 		)
 	}
 
@@ -155,7 +155,7 @@ func (s *Source) OperationResponses() ([]*OperationResponse, error) {
 		name := operationResponse.Name
 		s.sourceGenerator.cfg.Models.Add(
 			name,
-			fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg(), templates.ToGo(name)),
+			fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg().Path(), templates.ToGo(name)),
 		)
 	}
 
@@ -175,7 +175,7 @@ func (s *Source) Query() (*Query, error) {
 
 	s.sourceGenerator.cfg.Models.Add(
 		s.schema.Query.Name,
-		fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg(), templates.ToGo(s.schema.Query.Name)),
+		fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg().Path(), templates.ToGo(s.schema.Query.Name)),
 	)
 
 	return &Query{
@@ -201,7 +201,7 @@ func (s *Source) Mutation() (*Mutation, error) {
 
 	s.sourceGenerator.cfg.Models.Add(
 		s.schema.Mutation.Name,
-		fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg(), templates.ToGo(s.schema.Mutation.Name)),
+		fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg().Path(), templates.ToGo(s.schema.Mutation.Name)),
 	)
 
 	return &Mutation{

--- a/clientgenv2/source.go
+++ b/clientgenv2/source.go
@@ -52,7 +52,7 @@ func (s *Source) Fragments() ([]*Fragment, error) {
 		name := fragment.Name
 		s.sourceGenerator.cfg.Models.Add(
 			name,
-			fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg(), templates.ToGo(name)),
+			fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg().Path(), templates.ToGo(name)),
 		)
 	}
 
@@ -172,7 +172,7 @@ func (s *Source) OperationResponses() ([]*OperationResponse, error) {
 		name := operationResponse.Name
 		s.sourceGenerator.cfg.Models.Add(
 			name,
-			fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg(), templates.ToGo(name)),
+			fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg().Path(), templates.ToGo(name)),
 		)
 	}
 
@@ -196,7 +196,7 @@ func (s *Source) Query() (*Query, error) {
 
 	s.sourceGenerator.cfg.Models.Add(
 		s.schema.Query.Name,
-		fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg(), templates.ToGo(s.schema.Query.Name)),
+		fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg().Path(), templates.ToGo(s.schema.Query.Name)),
 	)
 
 	return &Query{
@@ -218,7 +218,7 @@ func (s *Source) Mutation() (*Mutation, error) {
 
 	s.sourceGenerator.cfg.Models.Add(
 		s.schema.Mutation.Name,
-		fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg(), templates.ToGo(s.schema.Mutation.Name)),
+		fmt.Sprintf("%s.%s", s.sourceGenerator.client.Pkg().Path(), templates.ToGo(s.schema.Mutation.Name)),
 	)
 
 	return &Mutation{


### PR DESCRIPTION
## Problem Statement

`clientgen` and `clientgenv2` currently pass a go type in the following format when adding a model to the source generator config. 

Example current go type format:
```
package [PACKAGE_NAME (\"[PACKAGE_PATH]\").[MODEL_NAME]"
```

Example current go type:
```
package client (\"github.com/foo/bar/client\")".Query
```

This is a malformed go type can result in config validation errors in gqlgen, ex:

```
validation failed: packages.Load: -: malformed import path "package client (\"github.com/foo/bar/client\")": invalid char ' '
```

## Solution
This pull request updates `clientgen` and `clientgenv2` to pass a valid formatted go type when adding a model to the source generator config. 

Example pull request go type format:

```
[PACKAGE_PATH].[MODEL_NAME]
```

Example pull request go type:
```
github.com/foo/bar/client.Query
```

This should avoid config validation errors, among other possible errors and unexpected behavior.