### PR TITLE
use standard json.Unmarshal instead of custom

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/Yamashou/gqlgenc/graphqljson"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
@@ -175,7 +174,7 @@ func unmarshal(data []byte, res interface{}) error {
 		return errors
 	}
 
-	if err := graphqljson.UnmarshalData(resp.Data, res); err != nil {
+	if err := json.Unmarshal(resp.Data, res); err != nil {
 		return fmt.Errorf("failed to decode data into response %s: %w", string(data), err)
 	}
 


### PR DESCRIPTION
I have a very complex response from the API and the graphqljson.UnmarshalData throws errors. After changing to standard json.Unmarshal everything works fine.