### PR TITLE
gqlgenc generates test template

### DIFF
--- a/clientgen/template.go
+++ b/clientgen/template.go
@@ -1,6 +1,7 @@
 package clientgen
 
 import (
+	_ "embed"
 	"fmt"
 
 	"github.com/99designs/gqlgen/codegen/config"
@@ -8,9 +9,13 @@ import (
 	gqlgencConfig "github.com/Yamashou/gqlgenc/config"
 )
 
+//go:embed template.gotpl
+var template string
+
 func RenderTemplate(cfg *config.Config, query *Query, mutation *Mutation, fragments []*Fragment, operations []*Operation, operationResponses []*OperationResponse, generateCfg *gqlgencConfig.GenerateConfig, client config.PackageConfig) error {
 	if err := templates.Render(templates.Options{
 		PackageName: client.Package,
+		Template:    template,
 		Filename:    client.Filename,
 		Data: map[string]interface{}{
 			"Query":               query,


### PR DESCRIPTION
When running as a plugin, roots will get-auto populated w/ test.tpl resulting in nonsense being generated. By explicitly specifying the template, we fix this

<img width="768" alt="image" src="https://user-images.githubusercontent.com/83933037/188709614-e745e701-3019-4a22-8c67-1435936b14da.png">
