### PR TITLE
add map support for json parser

### DIFF
--- a/graphqljson/graphql.go
+++ b/graphqljson/graphql.go
@@ -146,9 +146,13 @@ func (d *Decoder) decode() error {
 
 			// We've just consumed the current token, which was the key.
 			// Read the next token, which should be the value.
-			// If it's of json.RawMessage type, decode the value.
+			// If it's of json.RawMessage or map type, decode the value.
 			if matchingFieldValue.Type() == reflect.TypeOf(json.RawMessage{}) {
 				var data json.RawMessage
+				err = d.jsonDecoder.Decode(&data)
+				tok = data
+			} else if matchingFieldValue.Type() == reflect.TypeOf(map[string]interface{}{}) {
+				var data map[string]interface{}
 				err = d.jsonDecoder.Decode(&data)
 				tok = data
 			} else {
@@ -183,7 +187,7 @@ func (d *Decoder) decode() error {
 		}
 
 		switch tok := tok.(type) {
-		case string, json.Number, bool, nil, json.RawMessage:
+		case string, json.Number, bool, nil, json.RawMessage, map[string]interface{}:
 			// Value.
 
 			for i := range d.vs {

--- a/graphqljson/graphql.go
+++ b/graphqljson/graphql.go
@@ -147,15 +147,16 @@ func (d *Decoder) decode() error {
 			// We've just consumed the current token, which was the key.
 			// Read the next token, which should be the value.
 			// If it's of json.RawMessage or map type, decode the value.
-			if matchingFieldValue.Type() == reflect.TypeOf(json.RawMessage{}) {
+			switch matchingFieldValue.Type() {
+			case reflect.TypeOf(json.RawMessage{}):
 				var data json.RawMessage
 				err = d.jsonDecoder.Decode(&data)
 				tok = data
-			} else if matchingFieldValue.Type() == reflect.TypeOf(map[string]interface{}{}) {
+			case reflect.TypeOf(map[string]interface{}{}):
 				var data map[string]interface{}
 				err = d.jsonDecoder.Decode(&data)
 				tok = data
-			} else {
+			default:
 				tok, err = d.jsonDecoder.Token()
 			}
 

--- a/graphqljson/graphql_test.go
+++ b/graphqljson/graphql_test.go
@@ -563,3 +563,29 @@ func TestUnmarshalGraphQL_jsonRawMessageInFragment(t *testing.T) {
 		t.Error(diff)
 	}
 }
+
+func TestUnmarshalGraphQL_map(t *testing.T) {
+	t.Parallel()
+	type query struct {
+		Outputs map[string]interface{}
+	}
+	var got query
+	err := graphqljson.UnmarshalData([]byte(`{
+			"outputs":{
+                                 "vpc":"1",
+                                 "worker_role_arn":"2"
+        	}
+	}`), &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := query{
+		map[string]interface{}{
+			"vpc":             "1",
+			"worker_role_arn": "2",
+		},
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Error(diff)
+	}
+}


### PR DESCRIPTION
Currently, there is no support for a schema with `map[string]interface{}`. This PR extends the decode method to unmarshal the map type. 

It was the main reason why I opened the previous issue: #141
All tests are passing right now
