### PR TITLE
optionally specify directory to load .gqlgenc.yml from

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ Execute the following command on same directory for .gqlgenc.yml
 gqlgenc
 ```
 
+or if you want to specify a different directory where .gqlgenc.yml file resides
+(e.g. in this example the directory is *schemas*):
+
+```shell script
+gqlgenc generate --configdir schemas
+```
+
 ### With gqlgen
 
 Do this when creating a server and client for Go.

--- a/config/config.go
+++ b/config/config.go
@@ -50,19 +50,13 @@ func (a StringList) Has(file string) bool {
 	return false
 }
 
-// LoadConfigFromDefaultLocations looks for a config file in the current directory, and all parent directories
+// LoadConfigFromDefaultLocations looks for a config file in the specified directory, and all parent directories
 // walking up the tree. The closest config file will be returned.
-func LoadConfigFromDefaultLocations() (*Config, error) {
-	cfgFile, err := findCfg()
+func LoadConfigFromDefaultLocations(dir string) (*Config, error) {
+	cfgFile, err := findCfg(dir)
 	if err != nil {
 		return nil, err
 	}
-
-	err = os.Chdir(filepath.Dir(cfgFile))
-	if err != nil {
-		return nil, fmt.Errorf("unable to enter config dir: %w", err)
-	}
-
 	return LoadConfig(cfgFile)
 }
 
@@ -74,10 +68,17 @@ type EndPointConfig struct {
 
 // findCfg searches for the config file in this directory and all parents up the tree
 // looking for the closest match
-func findCfg() (string, error) {
-	dir, err := os.Getwd()
+func findCfg(path string) (string, error) {
+	var err error
+	var dir string
+	if path == "." {
+		dir, err = os.Getwd()
+	} else {
+		dir = path
+		_, err = os.Stat(dir)
+	}
 	if err != nil {
-		return "", fmt.Errorf("unable to get working dir to findCfg: %w", err)
+		return "", fmt.Errorf("unable to get directory \"%s\" to findCfg: %w", dir, err)
 	}
 
 	cfg := findCfgInDir(dir)

--- a/go.mod
+++ b/go.mod
@@ -6,14 +6,18 @@ require (
 	github.com/99designs/gqlgen v0.17.19
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.0
+	github.com/urfave/cli/v2 v2.17.1
 	github.com/vektah/gqlparser/v2 v2.5.1
 	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
 	github.com/agnivade/levenshtein v1.1.1 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/sys v0.0.0-20220915200043-7b5979e65e41 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -36,6 +38,7 @@ github.com/mitchellh/mapstructure v1.3.1 h1:cCBH2gTD2K0OtLlv/Y5H01VQCqmlDxz30kS5
 github.com/mitchellh/mapstructure v1.3.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
@@ -46,8 +49,11 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/urfave/cli/v2 v2.8.1/go.mod h1:Z41J9TPoffeoqP0Iza0YbAhGvymRdZAd2uPmZ5JxRdY=
+github.com/urfave/cli/v2 v2.17.1 h1:UzjDEw2dJQUE3iRaiNQ1VrVFbyAtKGH3VdkMoHA58V0=
+github.com/urfave/cli/v2 v2.17.1/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
 github.com/vektah/gqlparser/v2 v2.5.1 h1:ZGu+bquAY23jsxDRcYpWjttRZrUz07LbiY77gUOHcr4=
 github.com/vektah/gqlparser/v2 v2.5.1/go.mod h1:mPgqFBu/woKTVYWyNk8cO3kh4S/f4aRFZrvOnp3hmCs=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
+	"github.com/urfave/cli/v2"
 	"os"
 
 	"github.com/99designs/gqlgen/api"
@@ -12,23 +12,48 @@ import (
 	"github.com/Yamashou/gqlgenc/generator"
 )
 
-func main() {
-	ctx := context.Background()
-	cfg, err := config.LoadConfigFromDefaultLocations()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%+v", err.Error())
-		os.Exit(2)
-	}
-
-	clientGen := api.AddPlugin(clientgen.New(cfg.Query, cfg.Client, cfg.Generate))
-	if cfg.Generate != nil {
-		if cfg.Generate.ClientV2 {
-			clientGen = api.AddPlugin(clientgenv2.New(cfg.Query, cfg.Client, cfg.Generate))
+var generateCmd = &cli.Command{
+	Name:  "generate",
+	Usage: "generate a graphql client based on schema",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "configdir, c", Usage: "the directory with configuration file", Value: "."},
+	},
+	Action: func(ctx *cli.Context) error {
+		configDir := ctx.String("configdir")
+		cfg, err := config.LoadConfigFromDefaultLocations(configDir)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "%+v", err.Error())
+			os.Exit(2)
 		}
+
+		clientGen := api.AddPlugin(clientgen.New(cfg.Query, cfg.Client, cfg.Generate))
+		if cfg.Generate != nil {
+			if cfg.Generate.ClientV2 {
+				clientGen = api.AddPlugin(clientgenv2.New(cfg.Query, cfg.Client, cfg.Generate))
+			}
+		}
+
+		if err := generator.Generate(ctx.Context, cfg, clientGen); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "%+v", err.Error())
+			os.Exit(4)
+		}
+		return nil
+	},
+}
+
+func main() {
+
+	app := cli.NewApp()
+	app.Name = "gqlgenc"
+	app.Description = "This is a library for quickly creating strictly typed graphql client in golang"
+	app.Usage = generateCmd.Usage
+	app.DefaultCommand = "generate"
+	app.Commands = []*cli.Command{
+		generateCmd,
 	}
 
-	if err := generator.Generate(ctx, cfg, clientGen); err != nil {
-		fmt.Fprintf(os.Stderr, "%+v", err.Error())
-		os.Exit(4)
+	if err := app.Run(os.Args); err != nil {
+		_, _ = fmt.Fprint(os.Stderr, err.Error()+"\n")
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
I prefer to keep a root directory of my project clean and want to be able to specify a directory where to load .gqlgenc.yml file from.

You can still run

```
gqlgenc
```

without any arguments to apply a current behavior of loading .gqlgenc.yml from a current directory, or you can specify the exact location of the .gqlgenc.yml file, by running app such as

```
gqlgenc generate --configdir ./schemas
```

in this case .gqlgenc.yml will be loaded from a ./schemas directory in current folder

I have added urfave dependency into "gqlgenc" project, but main "gqlgen" project also uses it.

