### PR TITLE
Fix indeterministic fragment order in operation document string

### DIFF
--- a/clientgenv2/query.go
+++ b/clientgenv2/query.go
@@ -60,14 +60,14 @@ func fragmentsInOperationDefinition(operation *ast.OperationDefinition) ast.Frag
 }
 
 func fragmentsUnique(fragments ast.FragmentDefinitionList) ast.FragmentDefinitionList {
-	uniqueMap := make(map[string]*ast.FragmentDefinition)
+	seenFragments := make(map[string]struct{}, len(fragments))
+	uniqueFragments := make(ast.FragmentDefinitionList, 0, len(fragments))
 	for _, fragment := range fragments {
-		uniqueMap[fragment.Name] = fragment
-	}
-
-	uniqueFragments := make(ast.FragmentDefinitionList, 0, len(uniqueMap))
-	for _, fragment := range uniqueMap {
+		if _, seen := seenFragments[fragment.Name]; seen {
+			continue
+		}
 		uniqueFragments = append(uniqueFragments, fragment)
+		seenFragments[fragment.Name] = struct{}{}
 	}
 
 	return uniqueFragments

--- a/clientgenv2/query.go
+++ b/clientgenv2/query.go
@@ -63,7 +63,7 @@ func fragmentsUnique(fragments ast.FragmentDefinitionList) ast.FragmentDefinitio
 	seenFragments := make(map[string]struct{}, len(fragments))
 	uniqueFragments := make(ast.FragmentDefinitionList, 0, len(fragments))
 	for _, fragment := range fragments {
-		if _, seen := seenFragments[fragment.Name]; seen {
+		if _, ok := seenFragments[fragment.Name]; ok {
 			continue
 		}
 		uniqueFragments = append(uniqueFragments, fragment)


### PR DESCRIPTION
Ive been using gqlgenc a lot recently, and I have noticed that for queries/mutations that use several fragments, each time I run `gqlgenc`, the order of the fragments in the operation document string change order. This causes generation to not be deterministic for me. For operations with only a couple of fragments, generation seemed to be deterministic. 

I had a look at the source code and discovered in the `fragmentsUnique` function, a map of unique fragments was being created and then the map was used to create a slice of those unique fragments. This explains why my fragments were changing order. To fix it have have modified the way you create the slice of unique fragments to ensure the order is deterministic.

This change would be very helpful to me so i can run `gqlgenc` multiple times, and get the same generated files if nothing has changed.

For reference, i only use `clientgenv2`, i have not looked at the source for `clientgen`, so i do not know if it suffers the same problem.