### PR TITLE
Prevent a panic in case of the schema does not have any Query or Mutation

### DIFF
--- a/clientgenv2/client.go
+++ b/clientgenv2/client.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/99designs/gqlgen/plugin"
+
 	gqlgencConfig "github.com/Yamashou/gqlgenc/config"
 )
 
@@ -52,14 +53,21 @@ func (p *Plugin) MutateConfig(cfg *config.Config) error {
 	// 3. Generate code from template and document source
 	sourceGenerator := NewSourceGenerator(cfg, p.Client)
 	source := NewSource(cfg.Schema, queryDocument, sourceGenerator, p.GenerateConfig)
-	query, err := source.Query()
-	if err != nil {
-		return fmt.Errorf("generating query object: %w", err)
+
+	var query *Query
+	if source.schema.Query != nil {
+		query, err = source.Query()
+		if err != nil {
+			return fmt.Errorf("generating query object: %w", err)
+		}
 	}
 
-	mutation, err := source.Mutation()
-	if err != nil {
-		return fmt.Errorf("generating mutation object: %w", err)
+	var mutation *Mutation
+	if source.schema.Mutation != nil {
+		mutation, err = source.Mutation()
+		if err != nil {
+			return fmt.Errorf("generating mutation object: %w", err)
+		}
 	}
 
 	fragments, err := source.Fragments()


### PR DESCRIPTION
## What

- Prevent a panic in case of the schema does not have any Query or Mutation

## Why

The current `gqlgenc` causes a panic like the one below when the target GraphQL schema does not have Query or Mutation. 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x68 pc=0x916a39]

goroutine 1 [running]:
github.com/Yamashou/gqlgenc/clientgenv2.(*SourceGenerator).NewResponseFieldsByDefinition(0xc004057840, 0x0)
        /path/to/go/pkg/mod/github.com/!yamashou/gqlgenc@v0.13.5/clientgenv2/source_generator.go:107 +0x39
```

If I understand correctly, a GraphQL schema that does not have Query or Mutation is valid. In my case, I want to use `gqlgenc` with the GraphQL schema that does not have any Mutation.