### PR TITLE
Returan data when errors

### DIFF
--- a/clientgenv2/template.gotpl
+++ b/clientgenv2/template.gotpl
@@ -68,7 +68,12 @@ type {{ .Query.Name | go }} {{ .Query.Type | ref }}
 			}
 
 			var res {{ $model.ResponseStructName | go }}
-			if err := c.Client.Post(ctx, "{{ $model.Name }}", {{ $model.Name|go }}Document, &res, vars, interceptors...); err != nil {
+			err := c.Client.Post(ctx, "{{ $model.Name }}", {{ $model.Name|go }}Document, &res, vars, interceptors...)
+			if err != nil {
+				if c.Client.ParseDataWhenErrors && &res != nil {
+					return &res, err
+				}
+
 				return nil, err
 			}
 

--- a/clientgenv2/template.gotpl
+++ b/clientgenv2/template.gotpl
@@ -68,9 +68,8 @@ type {{ .Query.Name | go }} {{ .Query.Type | ref }}
 			}
 
 			var res {{ $model.ResponseStructName | go }}
-			err := c.Client.Post(ctx, "{{ $model.Name }}", {{ $model.Name|go }}Document, &res, vars, interceptors...)
-			if err != nil {
-				if c.Client.ParseDataWhenErrors && &res != nil {
+			if err := c.Client.Post(ctx, "{{ $model.Name }}", {{ $model.Name|go }}Document, &res, vars, interceptors...); err != nil {
+				if c.Client.ParseDataWhenErrors {
 					return &res, err
 				}
 


### PR DESCRIPTION
# What
- When ParseDataWhenErrors is set to true, the function will return not only errors but also data field by res variable.

```
ParseDataWhenErrors: true
```

# Why
In the current version of gqlgenc, even if ParseDataWhenErrors is set to true, only err is returned, making it impossible to compare the data field in tests. It's likely that users who set ParseDataWhenErrors to true also want to compare res at the same time.