### PR TITLE
Bugfix When the base graphql operation is in lower case the generated…

### DIFF
--- a/clientgenv2/source_generator.go
+++ b/clientgenv2/source_generator.go
@@ -3,6 +3,8 @@ package clientgenv2
 import (
 	"fmt"
 	"go/types"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"strings"
 
 	"github.com/99designs/gqlgen/codegen/config"
@@ -156,7 +158,7 @@ func (r *SourceGenerator) NewResponseFieldsByDefinition(definition *ast.Definiti
 }
 
 func NewLayerTypeName(base, thisField string) string {
-	return fmt.Sprintf("%s_%s", base, thisField)
+	return fmt.Sprintf("%s_%s", cases.Title(language.Und, cases.NoLower).String(base), thisField)
 }
 
 func (r *SourceGenerator) NewResponseField(selection ast.Selection, typeName string) *ResponseField {


### PR DESCRIPTION
Bugfix When the base graphql operation starts with a  lowercase name the generated response data structures are also generated as private structs (with lower case) but are used in public getter functions. They should start with a capital character for their name. 

This bugfix makes sure that the type name always starts with a capital character, so its exported and can be used outside the generated package