### PR TITLE
Fix multiple schemas in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -136,6 +136,7 @@ func LoadConfig(filename string) (*Config, error) {
 	}
 
 	// https://github.com/99designs/gqlgen/blob/3a31a752df764738b1f6e99408df3b169d514784/codegen/config/config.go#L120
+	files := StringList{}
 	for _, f := range cfg.SchemaFilename {
 		var matches []string
 
@@ -168,15 +169,14 @@ func LoadConfig(filename string) (*Config, error) {
 			}
 		}
 
-		files := StringList{}
 		for _, m := range matches {
 			if !files.Has(m) {
 				files = append(files, m)
 			}
 		}
-
-		cfg.SchemaFilename = files
 	}
+
+	cfg.SchemaFilename = files
 
 	models := make(config.TypeMap)
 	if cfg.Models != nil {


### PR DESCRIPTION
```
failed to load schema: load local schema failed: loadLocalSchema: xxx.graphql:6: Undefined directive goField.
```

```yaml
schema:
  - ./directive/*.graphql
  - ./scalar/*.graphql
  - ./resolver/*.graphql
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved configuration file handling for enhanced application performance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->