### PR TITLE
Keep `cfg.SchemaFilename` nil if "schema" is empty

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -176,7 +176,9 @@ func LoadConfig(filename string) (*Config, error) {
 		}
 	}
 
-	cfg.SchemaFilename = files
+	if len(files) > 0 {
+		cfg.SchemaFilename = files
+	}
 
 	models := make(config.TypeMap)
 	if cfg.Models != nil {


### PR DESCRIPTION
This PR solves the problem that the latest version of gqlgenc cannot read schema from remote servers.

I think merging this PR will resolve Issue #194 .

## What has changed

### Current behavior
The value of `cfg.SchemaFilename` is rewritten from nil to `config.StringList{}` after the LoadConfig function is executed, if schema is not specified in config.

### Behavior after this change
If `schema` is not specified, the value of `cfg.SchemaFilename` remains nil after the LoadConfig function is executed.

## Why this change is necessary

LoadSchema, the subsequent process, determines whether to read schema from local files or remote servers according to whether `cfg.SchemaFilename` is nil or not.

Currently `cfg.SchemaFilename` is not nil, which is not the expected behavior if the schema is read from a remote server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the configuration logic to dynamically assign the schema filename based on available files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->