### PR TITLE
Make gqlgen StructFieldsAlwaysPointers configurable

### DIFF
--- a/clientgenv2/source_generator.go
+++ b/clientgenv2/source_generator.go
@@ -224,9 +224,14 @@ func (r *SourceGenerator) NewResponseField(selection ast.Selection, typeName str
 			nil,
 		)
 
+		var typ types.Type = baseType
+		if r.cfg.StructFieldsAlwaysPointers {
+			typ = types.NewPointer(baseType)
+		}
+
 		return &ResponseField{
 			Name:             selection.Name,
-			Type:             types.NewPointer(baseType),
+			Type:             typ,
 			IsFragmentSpread: true,
 			ResponseFields:   fieldsResponseFields,
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -201,6 +201,11 @@ func LoadConfig(filename string) (*Config, error) {
 		sources = append(sources, &ast.Source{Name: filename, Input: string(schemaRaw)})
 	}
 
+	structFieldsAlwaysPointers := true
+	if cfg.Generate != nil && cfg.Generate.StructFieldsAlwaysPointers != nil {
+		structFieldsAlwaysPointers = *cfg.Generate.StructFieldsAlwaysPointers
+	}
+
 	cfg.GQLConfig = &config.Config{
 		Model:    cfg.Model,
 		Models:   models,
@@ -209,7 +214,7 @@ func LoadConfig(filename string) (*Config, error) {
 		Exec:                          config.ExecConfig{Filename: "generated.go"},
 		Directives:                    map[string]config.DirectiveConfig{},
 		Sources:                       sources,
-		StructFieldsAlwaysPointers:    true,
+		StructFieldsAlwaysPointers:    structFieldsAlwaysPointers,
 		ReturnPointersInUmarshalInput: false,
 		ResolversAlwaysReturnPointers: true,
 		NullableInputOmittable:        false,

--- a/config/generate_config.go
+++ b/config/generate_config.go
@@ -13,7 +13,8 @@ type GenerateConfig struct {
 	OmitEmptyTypes      *bool   `yaml:"omitEmptyTypes,omitempty"`
 	// Deprecated: not working because v1 is deleted. Must use ClientV2
 	// if true, used client v2 in generate code
-	ClientV2 bool `yaml:"clientV2,omitempty"`
+	ClientV2                   bool  `yaml:"clientV2,omitempty"`
+	StructFieldsAlwaysPointers *bool `yaml:"struct_fields_always_pointers,omitempty"`
 }
 
 func (c *GenerateConfig) ShouldGenerateClient() bool {

--- a/config/generate_config.go
+++ b/config/generate_config.go
@@ -14,7 +14,7 @@ type GenerateConfig struct {
 	// Deprecated: not working because v1 is deleted. Must use ClientV2
 	// if true, used client v2 in generate code
 	ClientV2                   bool  `yaml:"clientV2,omitempty"`
-	StructFieldsAlwaysPointers *bool `yaml:"struct_fields_always_pointers,omitempty"`
+	StructFieldsAlwaysPointers *bool `yaml:"structFieldsAlwaysPointers,omitempty"`
 }
 
 func (c *GenerateConfig) ShouldGenerateClient() bool {


### PR DESCRIPTION
When updating to a more recent version of `gqlgenc`, we encountered issues with the generation of models for non-null fields. Non-null structs fields are always pointers instead of being defined as values. We were impacted by the following two changes:
- Match gqlgen default settings: #202
- struct type field for fragment is pointer: https://github.com/Yamashou/gqlgenc/pull/104/commits/2bb5b94f1784f7dc1cbd8aee7228ff226192457e. This one is quite old, but that change was in only done in client v2, and we were still using client v1.

This PR is to make the generation of non-null structs fields as pointers configurable. 

I've used the same name used by `gqlgen` for the similar config: `struct_fields_always_pointers`. Unfortunately, that name doesn't fit well with other settings like `clientInterfaceName` and `omitEmptyTypes`. Do you prefer a different name? Perhaps `structFieldsAlwaysPointers`?