### PR TITLE
Add test case for nested structs

### DIFF
--- a/clientv2/client_test.go
+++ b/clientv2/client_test.go
@@ -578,6 +578,15 @@ func TestMarshalJSON(t *testing.T) {
 		Name   string `json:"name"`
 		Number Number `json:"number"`
 	}
+
+	// example nested struct
+	type WhereInput struct {
+		Not *WhereInput `json:"not,omitempty"`
+		ID  *string     `json:"id,omitempty"`
+	}
+
+	testID := "1"
+
 	testDate := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
 	type args struct {
 		v any
@@ -607,6 +616,23 @@ func TestMarshalJSON(t *testing.T) {
 				},
 			},
 			want: []byte(`{"operationName":"query", "query":"query ($input: Number!) { input }","variables":{"input":"TWO"}}`),
+		},
+		{
+			name: "marshal nested",
+			args: args{
+				v: Request{
+					OperationName: "query",
+					Query:         `query ($input: Number!) { input }`,
+					Variables: map[string]any{
+						"where": WhereInput{
+							Not: &WhereInput{
+								ID: &testID,
+							},
+						},
+					},
+				},
+			},
+			want: []byte(`{"operationName":"query", "query":"query ($input: Number!) { input }","variables":{"where":{"not":{"id":"1"}}}}`),
 		},
 		{
 			name: "marshal a struct with custom marshaler",


### PR DESCRIPTION
Adds a test for https://github.com/Yamashou/gqlgenc/issues/219

On version `v0.21.2`:

```
=== RUN   TestMarshalJSON/marshal_nested
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0x140201e0380 stack=[0x140201e0000, 0x140401e0000]
fatal error: stack overflow
```

On latest: 

```
    --- PASS: TestMarshalJSON/marshal_NumberOne (0.00s)
    --- PASS: TestMarshalJSON/marshal_NumberTwo (0.00s)
    --- PASS: TestMarshalJSON/marshal_nested (0.00s)
    --- PASS: TestMarshalJSON/marshal_a_struct_with_custom_marshaler (0.00s)
    --- PASS: TestMarshalJSON/marshal_map_with_custom_marshaler (0.00s)
    --- PASS: TestMarshalJSON/marshal_time.Time (0.00s)
    --- PASS: TestMarshalJSON/marshal_time.Time#01 (0.00s)
PASS
ok  	github.com/Yamashou/gqlgenc/clientv2	0.140s
```