### PR TITLE
Update version in main.go to 0.22.1

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const version = "0.21.1"
+const version = "0.22.1"
 
 var versionCmd = &cli.Command{
 	Name:  "version",


### PR DESCRIPTION
Version in main.go is still set at 0.21.1. This PR bumps the version to 0.22.1.  Can we get a release of 0.22.1 with just the version change?