### PR TITLE
use encoding.TextMarshaler if a value implements it

### DIFF
--- a/clientv2/client_test.go
+++ b/clientv2/client_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/gqlerror"
@@ -735,6 +736,23 @@ func TestMarshalJSON(t *testing.T) {
 				},
 			},
 			want: []byte(`{"T":{"time":"2021-01-01T00:00:00Z"}}`),
+		},
+		{
+			name: "marshal uuid",
+			args: args{
+				v: struct {
+					T struct {
+						UUID uuid.UUID `json:"uuid"`
+					}
+				}{
+					T: struct {
+						UUID uuid.UUID `json:"uuid"`
+					}{
+						UUID: uuid.MustParse("0bd42821-463a-4224-a41b-c5861fc91268"),
+					},
+				},
+			},
+			want: []byte(`{"T":{"uuid":"0bd42821-463a-4224-a41b-c5861fc91268"}}`),
 		},
 	}
 	for _, tt := range tests {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/99designs/gqlgen v0.17.44
 	github.com/google/go-cmp v0.6.0
+	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.8.4
 	github.com/urfave/cli/v2 v2.27.1
 	github.com/vektah/gqlparser/v2 v2.5.11
@@ -16,7 +17,6 @@ require (
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sosodev/duration v1.2.0 // indirect


### PR DESCRIPTION
I would like to use a type provided by 3rd party package. When the type does not implement neither graphql.Marshaler nor json.Marshaler, the result of MarshalJSON generates an unexpected string in some cases.

For example, assuming using github.com/google/uuid.uuid.UUID in a variable,

This is an example schema.

```
type Query {
    uuidToString(uuid: UUID!): String!
}

scalar UUID
```

Bind the scalar to in gqlgenc.yaml

```
models:
  UUID:
    model: github.com/google/uuid.UUID
```

Then, gqlgenc generates a code to marshal a variable like this:

```go
	vars := map[string]any{
		"uuid":   uuid.New(),
	}
	b, err := clientv2.MarshalJSON(vars)
        ...
        fmt.Printf("json: %s\n", b)
```

This generates a json value,

```
json: {"uuid":[173,99,127,52,45,165,69,156,136,157,99,98,166,115,160,109]} // unexpected
```

However, if we use json.Marshal directly instead of MarshalJSON, they generate different json values.

```
	vars := map[string]any{
		"uuid":   uuid.New(),
	}
	b, err := clientv2.MarshalJSON(vars)
        ...
        fmt.Printf("json: %s\n", b)
	b2, err := json.Marshal(vars)
        ...
        fmt.Printf("json: %s\n", b2)
```

```
json {"uuid":[140,251,26,253,170,172,74,61,164,123,188,187,190,136,237,190]}
json {"uuid":"8cfb1afd-aaac-4a3d-a47b-bcbbbe88edbe"}
```

This is because json.Marshal's encoder supports encoding.TextMarshaler.
The description: https://cs.opensource.google/go/go/+/master:src/encoding/json/encode.go;l=32-40
The implementation: https://cs.opensource.google/go/go/+/master:src/encoding/json/encode.go;l=379-395

So I think it's better to respect encoding.TextMarshaler in MarshalJSON too. The current implementation of MarshalJSON calls json.Marshaler.MarshalJSON if a value implements json.Marshaler interface.