### PR TITLE
update for gqlgen 0.17.54 federation change

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
         go-version-file: go.mod
 
     - name: Install Lint
-      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
+      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
 
     - name: Lint
       run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,13 +23,10 @@ linters:
     - gochecknoinits
     - gochecknoglobals
     - godox
-    - maligned
     - gocognit
     - gocyclo
-    - interfacer
     - gomnd
-    - goerr113
-    - exhaustivestruct
+    - err113
     - errorlint # TODO able this lint
     - forbidigo
     - cyclop
@@ -37,30 +34,24 @@ linters:
     - errname
     - varnamelen
     - nilnil
-    - structcheck
     - exhaustruct
     - nonamedreturns
-    - golint
-    - ifshort
-    - nosnakecase
-    - deadcode
-    - scopelint
-    - varcheck
     - depguard
     - musttag
     - paralleltest
     - nlreturn
+    - mnd
   fast: true
 
 issues:
   fix: true
   exclude-files:
     - _test\.go
-    - examples/**/*\.go
+    - example/*/*.go
   max-issues-per-linter: 0
   max-same-issues: 0
   exclude-dirs:
-    - examples
+    - example
   exclude-rules:
     # Test
     - path: _test\.go
@@ -83,10 +74,6 @@ issues:
       text: "`Extensions` is unused" # used in line 48
       linters:
         - structcheck
-    - path: introspection/query.go
-      text: "`Introspection` is unused" # used in config/config.go
-      linters:
-        - varcheck
     - path: config/config.go
       text: "`ClientV2` is unused" # used in config/config.go
       linters:

--- a/clientgenv2/source_generator.go
+++ b/clientgenv2/source_generator.go
@@ -46,7 +46,7 @@ func (rs ResponseFieldList) StructType() *types.Struct {
 			if !ok {
 				continue
 			}
-			for j := 0; j < typ.NumFields(); j++ {
+			for j := range typ.NumFields() {
 				vars = append(vars, typ.Field(j))
 				structTags = append(structTags, typ.Tag(j))
 			}

--- a/clientgenv2/template.go
+++ b/clientgenv2/template.go
@@ -90,7 +90,7 @@ func (g *GenGettersGenerator) GenFunc() func(name string, p types.Type) string {
 		}
 		var buf bytes.Buffer
 
-		for i := 0; i < it.NumFields(); i++ {
+		for i := range it.NumFields() {
 			field := it.Field(i)
 
 			returns := g.returnTypeName(field.Type(), false)

--- a/clientv2/client.go
+++ b/clientv2/client.go
@@ -332,8 +332,8 @@ func (c *Client) do(_ context.Context, req *http.Request, _ *GQLRequestInfo, res
 
 func (c *Client) parseResponse(body []byte, httpCode int, result interface{}) error {
 	errResponse := &ErrorResponse{}
-	isKOCode := httpCode < 200 || 299 < httpCode
-	if isKOCode {
+	isOKCode := httpCode < 200 || 299 < httpCode
+	if isOKCode {
 		errResponse.NetworkError = &HTTPError{
 			Code:    httpCode,
 			Message: fmt.Sprintf("Response body %s", string(body)),
@@ -345,7 +345,7 @@ func (c *Client) parseResponse(body []byte, httpCode int, result interface{}) er
 		var gqlErr *GqlErrorList
 		if errors.As(err, &gqlErr) {
 			errResponse.GqlErrors = &gqlErr.Errors
-		} else if !isKOCode {
+		} else if !isOKCode {
 			return err
 		}
 	}
@@ -535,7 +535,7 @@ type fieldInfo struct {
 func prepareFields(t reflect.Type) []fieldInfo {
 	num := t.NumField()
 	fields := make([]fieldInfo, 0, num)
-	for i := 0; i < num; i++ {
+	for i := range num {
 		f := t.Field(i)
 		if f.PkgPath != "" && !f.Anonymous { // Skip unexported fields unless they are embedded
 			continue
@@ -619,7 +619,7 @@ func encodeMap(v reflect.Value) ([]byte, error) {
 
 func encodeSlice(v reflect.Value) ([]byte, error) {
 	result := make([]json.RawMessage, v.Len())
-	for i := 0; i < v.Len(); i++ {
+	for i := range v.Len() {
 		encodedValue, err := encode(v.Index(i))
 		if err != nil {
 			return nil, err
@@ -631,7 +631,7 @@ func encodeSlice(v reflect.Value) ([]byte, error) {
 
 func encodeArray(v reflect.Value) ([]byte, error) {
 	result := make([]json.RawMessage, v.Len())
-	for i := 0; i < v.Len(); i++ {
+	for i := range v.Len() {
 		encodedValue, err := encode(v.Index(i))
 		if err != nil {
 			return nil, err

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.5
 toolchain go1.22.6
 
 require (
-	github.com/99designs/gqlgen v0.17.51
+	github.com/99designs/gqlgen v0.17.54
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/99designs/gqlgen v0.17.51 h1:KHLvUckplsZi14Zv1JdHkemXSkulksN/Dwe7VflePSQ=
-github.com/99designs/gqlgen v0.17.51/go.mod h1:77/+pVe6zlTsz++oUg2m8VLgzdUPHxjoAG3BxI5y8Rc=
+github.com/99designs/gqlgen v0.17.54 h1:AsF49k/7RJlwA00RQYsYN0T8cQuaosnV/7G1dHC3Uh8=
+github.com/99designs/gqlgen v0.17.54/go.mod h1:77/+pVe6zlTsz++oUg2m8VLgzdUPHxjoAG3BxI5y8Rc=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=

--- a/graphqljson/graphql.go
+++ b/graphqljson/graphql.go
@@ -273,7 +273,7 @@ func (d *Decoder) decode() error { //nolint:maintidx
 					if v.Kind() != reflect.Struct {
 						continue
 					}
-					for i := 0; i < v.NumField(); i++ {
+					for i := range v.NumField() {
 						if isGraphQLFragment(v.Type().Field(i)) || v.Type().Field(i).Anonymous {
 							// Add GraphQL fragment or embedded struct.
 							d.vs = append(d.vs, []reflect.Value{v.Field(i)})
@@ -352,7 +352,7 @@ func (d *Decoder) popAllVs() {
 // fieldByGraphQLName returns an exported struct field of struct v
 // that matches GraphQL name, or invalid reflect.Value if none found.
 func fieldByGraphQLName(v reflect.Value, name string) reflect.Value {
-	for i := 0; i < v.NumField(); i++ {
+	for i := range v.NumField() {
 		if v.Type().Field(i).PkgPath != "" {
 			// Skip unexported field.
 			continue

--- a/introspection/parse.go
+++ b/introspection/parse.go
@@ -109,7 +109,6 @@ func (p parser) parseDirectiveDefinition(directiveValue *DirectiveType) *ast.Dir
 func (p parser) parseObjectFields(typeVale *FullType) ast.FieldList {
 	fieldList := make(ast.FieldList, 0, len(typeVale.Fields))
 	for _, field := range typeVale.Fields {
-		field := field
 		typ := p.getType(&field.Type)
 		args := make(ast.ArgumentDefinitionList, 0, len(field.Args))
 		for _, arg := range field.Args {
@@ -134,7 +133,6 @@ func (p parser) parseObjectFields(typeVale *FullType) ast.FieldList {
 func (p parser) parseInputObjectFields(typeVale *FullType) ast.FieldList {
 	fieldList := make(ast.FieldList, 0, len(typeVale.InputFields))
 	for _, field := range typeVale.InputFields {
-		field := field
 		typ := p.getType(&field.Type)
 		fieldDefinition := &ast.FieldDefinition{
 			Description: pointerString(field.Description),


### PR DESCRIPTION
- bumps `github.com/99designs/gqlgen v0.17.54` 

- there was another breaking change to the function signature in `gqglen`, this time for `federation.New()` now requires the gqlgen config to be passed in and returns the `Federation` and error. I updated this [here](https://github.com/Yamashou/gqlgenc/compare/master...golanglemonade:gqlgenc:federation-gqlgen-breaking-change?expand=1#diff-ebe0c9061541da82c4de858d4996649ee6d33bf4036cb96200cc3f3ae891a536R65-R75).

- I also noticed when running the linter that it was failing to run at least locally because of a large number of warnings due to deprecated linters. I removed those from the `disable` and updated the failing linter errors (mostly around using `range` after go1.22). 
-  updates the linter version in actions to the latest version (`v1.61.0`)