### PR TITLE
HTTP Client as an interface

### DIFF
--- a/clientgenv2/template.gotpl
+++ b/clientgenv2/template.gotpl
@@ -26,7 +26,7 @@
 	    Client *clientv2.Client
 	}
 
-    func NewClient(cli *http.Client, baseURL string, options *clientv2.Options, interceptors ...clientv2.RequestInterceptor) {{- if .ClientInterfaceName }} {{ .ClientInterfaceName }} {{- else }} *Client {{- end }} {
+    func NewClient(cli clientv2.HttpClient, baseURL string, options *clientv2.Options, interceptors ...clientv2.RequestInterceptor) {{- if .ClientInterfaceName }} {{ .ClientInterfaceName }} {{- else }} *Client {{- end }} {
         return &Client{Client: clientv2.NewClient(cli, baseURL, options, interceptors...)}
     }
 

--- a/clientv2/client.go
+++ b/clientv2/client.go
@@ -20,6 +20,11 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
+type HttpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+	Post(url, contentType string, body io.Reader) (*http.Response, error)
+}
+
 type GQLRequestInfo struct {
 	Request *Request
 }
@@ -55,7 +60,7 @@ func ChainInterceptor(interceptors ...RequestInterceptor) RequestInterceptor {
 
 // Client is the http client wrapper
 type Client struct {
-	Client              *http.Client
+	Client              HttpClient
 	BaseURL             string
 	RequestInterceptor  RequestInterceptor
 	CustomDo            RequestInterceptorFunc
@@ -70,7 +75,7 @@ type Request struct {
 }
 
 // NewClient creates a new http client wrapper
-func NewClient(client *http.Client, baseURL string, options *Options, interceptors ...RequestInterceptor) *Client {
+func NewClient(client HttpClient, baseURL string, options *Options, interceptors ...RequestInterceptor) *Client {
 	c := &Client{
 		Client:  client,
 		BaseURL: baseURL,


### PR DESCRIPTION
Having HTTP Client as an interface allows us to use more complex http client implementations. The one I am personally interested at is [github.com/sethgrid/pester](https://github.com/sethgrid/pester) which allows us to use resilient  requests to remote GraphQL server by implementing a retry strategy on underlying HTTP requests.
The rest of the repository requires no change. All the existing generated code will be compatible with the proposed change.

Example:
```
package ein

import (
	"context"
	"net/http"
	"time"

	"github.com/sethgrid/pester"

        "github.com/Yamashou/gqlgenc/clientv2"
)

func NewEinHttpClientWithRetry(roundTripper http.RoundTripper) clientv2.HttpClient {
	client := pester.New()
	client.Transport = roundTripper
	client.Timeout = 120 * time.Second
	client.Concurrency = 1
	client.MaxRetries = 5
	client.Backoff = pester.ExponentialJitterBackoff
	client.RetryOnHTTP429 = true
	return client
}
```
