### PR TITLE
upgrade gopkg.in/yaml.v2 -> v3

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -15,7 +16,7 @@ import (
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/validator"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // Config extends the gqlgen basic config
@@ -125,7 +126,11 @@ func LoadConfig(filename string) (*Config, error) {
 	}
 
 	confContent := []byte(os.ExpandEnv(string(b)))
-	if err := yaml.UnmarshalStrict(confContent, &cfg); err != nil {
+
+	decoder := yaml.NewDecoder(bytes.NewReader(confContent))
+	decoder.KnownFields(true)
+
+	if err := decoder.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("unable to parse config: %w", err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.4
 	github.com/vektah/gqlparser/v2 v2.5.16
 	golang.org/x/text v0.18.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -26,5 +26,4 @@ require (
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/tools v0.24.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Updates `yaml.v2` -> `yaml.v3`.

See https://github.com/go-yaml/yaml/issues/602 for details on the `UnmarshalStrict` change. 