### PR TITLE
fix: infinite recursion in inputObject

### DIFF
--- a/querydocument/query_document.go
+++ b/querydocument/query_document.go
@@ -97,7 +97,8 @@ func collectInputObjectFieldsWithCycle(def *ast.Definition, schema *ast.Schema, 
 		return // この型は既に完全に処理済み
 	}
 
-	usedTypes[def.Name] = true // この型を使用済みとしてマーク
+	processedTypes[def.Name] = true // この型の処理が完了したことをマーク
+	usedTypes[def.Name] = true      // この型を使用済みとしてマーク
 
 	for _, field := range def.Fields {
 		var typeName string
@@ -115,8 +116,6 @@ func collectInputObjectFieldsWithCycle(def *ast.Definition, schema *ast.Schema, 
 			}
 		}
 	}
-
-	processedTypes[def.Name] = true // この型の処理が完了したことをマーク
 }
 
 // collectTypeFromTypeReference is a helper function to collect type names from type references


### PR DESCRIPTION
The processedType Map is not updated when there is a cycle in the type definitions and causes an infinite recursion. Updating the processedType Map before the cycle should solve the issue.

Co-authored-by: Jonathan Kohlhas <JonathanKohlhas@users.noreply.github.com>