### PR TITLE
Fix Conditional Logic for `OmitemptyTag`

### DIFF
--- a/config/generate_config.go
+++ b/config/generate_config.go
@@ -52,11 +52,11 @@ func (c *GenerateConfig) IsEnableClientJsonOmitemptyTag() bool {
 		return true
 	}
 
-	if c.EnableClientJsonOmitemptyTag != nil && *c.EnableClientJsonOmitemptyTag {
+	if c.EnableClientJsonOmitemptyTag == nil {
 		return true
 	}
 
-	return false
+	return *c.EnableClientJsonOmitemptyTag
 }
 
 func (c *GenerateConfig) GetClientInterfaceName() *string {

--- a/example/autobind/schema/schema.graphql
+++ b/example/autobind/schema/schema.graphql
@@ -13,7 +13,7 @@ type Mutation {
 
 type User {
     id: ID!
-    profile: Profile!
+    profile: Profile
 }
 
 type Profile {

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const version = "0.28.0"
+const version = "0.28.1"
 
 var versionCmd = &cli.Command{
 	Name:  "version",


### PR DESCRIPTION
Updated the conditional logic to return true when no value is specified for EnableClientJsonOmitemptyTag.

```go
func (c *GenerateConfig) IsEnableClientJsonOmitemptyTag() bool {
	if c == nil {
		return true
	}

	if c.EnableClientJsonOmitemptyTag == nil {
		return true
	}

	return *c.EnableClientJsonOmitemptyTag
}
```

This ensures that the default behavior remains consistent and returns true when the configuration is not explicitly set.




