### PR TITLE
fix type.Alias for any fields

### DIFF
--- a/clientgenv2/template.go
+++ b/clientgenv2/template.go
@@ -73,6 +73,8 @@ func (g *GenGettersGenerator) returnTypeName(t types.Type, nested bool) string {
 		return "any"
 	case *types.Map:
 		return "map[" + g.returnTypeName(it.Key(), true) + "]" + g.returnTypeName(it.Elem(), true)
+	case *types.Alias:
+		return g.returnTypeName(it.Underlying(), nested)
 	default:
 		return fmt.Sprintf("%T----", it)
 	}


### PR DESCRIPTION
The upstream changes to `any` were causing a `map[string]any` to be converted to:

```
 map[string]*Type.Alias----
```

This should resolve it by getting the underly type of the alias. 

