### PR TITLE
Fix generator for multiple fragment pattern

### DIFF
--- a/clientgenv2/source_generator.go
+++ b/clientgenv2/source_generator.go
@@ -150,6 +150,7 @@ func mergeFieldsRecursively(targetFields, sourceFields ResponseFieldList, preMer
 				Type: targetField.ResponseFields.StructType(),
 			})
 		} else {
+			targetFieldsMap[sourceField.Name] = sourceField
 			responseFieldList = append(responseFieldList, sourceField)
 		}
 	}


### PR DESCRIPTION
Fragment pattern support is now enabled in #254. 
However, if multiple fragments share the same name field, it causes a crash. 
I've fixed that issue.