### PR TITLE
leave go to its minimal required version from dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Yamashou/gqlgenc
 
-go 1.24.2
+go 1.23.8
 
 require (
 	github.com/99designs/gqlgen v0.17.71


### PR DESCRIPTION
- use go 1.23.8
- setting it to 1.24.2 force everyone to use this version at least

Reference: https://go.dev/ref/mod#go-mod-file-go