### PR TITLE
fix: make version a var

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const version = "0.31.0"
+var version = "0.31.0"
 
 var versionCmd = &cli.Command{
 	Name:  "version",


### PR DESCRIPTION
This makes overriding possible for packaging in case the version number is not up to date.

Related to: https://github.com/NixOS/nixpkgs/pull/398878