### PR TITLE
fix: filter enums when onlyUsedModels is enabled

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -23,14 +23,21 @@ func mutateHook(cfg *config.Config, usedTypes map[string]bool) func(b *modelgen.
 		// only generate used models
 		if cfg.Generate.OnlyUsedModels != nil && *cfg.Generate.OnlyUsedModels {
 			var newModels []*modelgen.Object
-
 			for _, model := range build.Models {
 				if usedTypes[model.Name] {
 					newModels = append(newModels, model)
 				}
 			}
-
 			build.Models = newModels
+
+			var newEnums []*modelgen.Enum
+			for _, enum := range build.Enums {
+				if usedTypes[enum.Name] {
+					newEnums = append(newEnums, enum)
+				}
+			}
+			build.Enums = newEnums
+
 			build.Interfaces = nil
 		}
 

--- a/generator/testdata/only_used_models/expected/client.go
+++ b/generator/testdata/only_used_models/expected/client.go
@@ -45,6 +45,17 @@ func (t *CreateMany_CreateTodos) GetTodos() []*CreateMany_CreateTodos_Todos {
 	return t.Todos
 }
 
+type GetBySortOrder_TodosBySortOrder struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetBySortOrder_TodosBySortOrder) GetID() string {
+	if t == nil {
+		t = &GetBySortOrder_TodosBySortOrder{}
+	}
+	return t.ID
+}
+
 type CreateMany struct {
 	CreateTodos *CreateMany_CreateTodos "json:\"createTodos,omitempty\" graphql:\"createTodos\""
 }
@@ -54,6 +65,17 @@ func (t *CreateMany) GetCreateTodos() *CreateMany_CreateTodos {
 		t = &CreateMany{}
 	}
 	return t.CreateTodos
+}
+
+type GetBySortOrder struct {
+	TodosBySortOrder []*GetBySortOrder_TodosBySortOrder "json:\"todosBySortOrder\" graphql:\"todosBySortOrder\""
+}
+
+func (t *GetBySortOrder) GetTodosBySortOrder() []*GetBySortOrder_TodosBySortOrder {
+	if t == nil {
+		t = &GetBySortOrder{}
+	}
+	return t.TodosBySortOrder
 }
 
 const CreateManyDocument = `mutation CreateMany ($todos: NewTodos!) {
@@ -83,6 +105,31 @@ func (c *Client) CreateMany(ctx context.Context, todos NewTodos, interceptors ..
 	return &res, nil
 }
 
+const GetBySortOrderDocument = `query GetBySortOrder ($order: SortOrder!) {
+	todosBySortOrder(order: $order) {
+		id
+	}
+}
+`
+
+func (c *Client) GetBySortOrder(ctx context.Context, order SortOrder, interceptors ...clientv2.RequestInterceptor) (*GetBySortOrder, error) {
+	vars := map[string]any{
+		"order": order,
+	}
+
+	var res GetBySortOrder
+	if err := c.Client.Post(ctx, "GetBySortOrder", GetBySortOrderDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
 var DocumentOperationNames = map[string]string{
-	CreateManyDocument: "CreateMany",
+	CreateManyDocument:     "CreateMany",
+	GetBySortOrderDocument: "GetBySortOrder",
 }

--- a/generator/testdata/only_used_models/expected/client.go
+++ b/generator/testdata/only_used_models/expected/client.go
@@ -17,7 +17,8 @@ func NewClient(cli clientv2.HttpClient, baseURL string, options *clientv2.Option
 }
 
 type CreateMany_CreateTodos_Todos struct {
-	ID string "json:\"id\" graphql:\"id\""
+	ID     string     "json:\"id\" graphql:\"id\""
+	Status TodoStatus "json:\"status\" graphql:\"status\""
 }
 
 func (t *CreateMany_CreateTodos_Todos) GetID() string {
@@ -25,6 +26,12 @@ func (t *CreateMany_CreateTodos_Todos) GetID() string {
 		t = &CreateMany_CreateTodos_Todos{}
 	}
 	return t.ID
+}
+func (t *CreateMany_CreateTodos_Todos) GetStatus() *TodoStatus {
+	if t == nil {
+		t = &CreateMany_CreateTodos_Todos{}
+	}
+	return &t.Status
 }
 
 type CreateMany_CreateTodos struct {
@@ -53,6 +60,7 @@ const CreateManyDocument = `mutation CreateMany ($todos: NewTodos!) {
 	createTodos(input: $todos) {
 		todos {
 			id
+			status
 		}
 	}
 }

--- a/generator/testdata/only_used_models/expected/models_gen.go
+++ b/generator/testdata/only_used_models/expected/models_gen.go
@@ -2,6 +2,13 @@
 
 package generated
 
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+)
+
 type NewTodo struct {
 	Text   string `json:"text"`
 	UserID string `json:"userId"`
@@ -9,4 +16,59 @@ type NewTodo struct {
 
 type NewTodos struct {
 	Todos []*NewTodo `json:"todos"`
+}
+
+type TodoStatus string
+
+const (
+	TodoStatusOpen TodoStatus = "OPEN"
+	TodoStatusDone TodoStatus = "DONE"
+)
+
+var AllTodoStatus = []TodoStatus{
+	TodoStatusOpen,
+	TodoStatusDone,
+}
+
+func (e TodoStatus) IsValid() bool {
+	switch e {
+	case TodoStatusOpen, TodoStatusDone:
+		return true
+	}
+	return false
+}
+
+func (e TodoStatus) String() string {
+	return string(e)
+}
+
+func (e *TodoStatus) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = TodoStatus(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid TodoStatus", str)
+	}
+	return nil
+}
+
+func (e TodoStatus) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *TodoStatus) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e TodoStatus) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
 }

--- a/generator/testdata/only_used_models/expected/models_gen.go
+++ b/generator/testdata/only_used_models/expected/models_gen.go
@@ -18,6 +18,61 @@ type NewTodos struct {
 	Todos []*NewTodo `json:"todos"`
 }
 
+type SortOrder string
+
+const (
+	SortOrderAsc  SortOrder = "ASC"
+	SortOrderDesc SortOrder = "DESC"
+)
+
+var AllSortOrder = []SortOrder{
+	SortOrderAsc,
+	SortOrderDesc,
+}
+
+func (e SortOrder) IsValid() bool {
+	switch e {
+	case SortOrderAsc, SortOrderDesc:
+		return true
+	}
+	return false
+}
+
+func (e SortOrder) String() string {
+	return string(e)
+}
+
+func (e *SortOrder) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = SortOrder(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid SortOrder", str)
+	}
+	return nil
+}
+
+func (e SortOrder) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *SortOrder) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e SortOrder) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 type TodoStatus string
 
 const (

--- a/generator/testdata/only_used_models/queries/createTodos.graphql
+++ b/generator/testdata/only_used_models/queries/createTodos.graphql
@@ -2,6 +2,7 @@ mutation CreateMany($todos: NewTodos!) {
     createTodos(input: $todos) {
         todos {
             id
+            status
         }
     }
 }

--- a/generator/testdata/only_used_models/queries/getBySortOrder.graphql
+++ b/generator/testdata/only_used_models/queries/getBySortOrder.graphql
@@ -1,0 +1,5 @@
+query GetBySortOrder($order: SortOrder!) {
+    todosBySortOrder(order: $order) {
+        id
+    }
+}

--- a/generator/testdata/only_used_models/schemas/schema.graphql
+++ b/generator/testdata/only_used_models/schemas/schema.graphql
@@ -19,8 +19,19 @@ type Todo {
     id: ID!
     text: String!
     userId: String!
+    status: TodoStatus!
 }
 
 type TodoPage {
     todos: [Todo!]!
+}
+
+enum TodoStatus {
+    OPEN
+    DONE
+}
+
+enum UnusedEnum {
+    FOO
+    BAR
 }

--- a/generator/testdata/only_used_models/schemas/schema.graphql
+++ b/generator/testdata/only_used_models/schemas/schema.graphql
@@ -1,5 +1,6 @@
 type Query {
     todos: [Todo!]!
+    todosBySortOrder(order: SortOrder!): [Todo!]!
 }
 
 input NewTodo {
@@ -20,6 +21,7 @@ type Todo {
     text: String!
     userId: String!
     status: TodoStatus!
+    unusedField: UnusedEnum
 }
 
 type TodoPage {
@@ -29,6 +31,11 @@ type TodoPage {
 enum TodoStatus {
     OPEN
     DONE
+}
+
+enum SortOrder {
+    ASC
+    DESC
 }
 
 enum UnusedEnum {

--- a/querydocument/query_document.go
+++ b/querydocument/query_document.go
@@ -74,7 +74,8 @@ func fragmentsInOperationWalker(selectionSet ast.SelectionSet) ast.FragmentDefin
 	return fragments
 }
 
-// CollectTypesFromQueryDocuments returns a map of type names used in query document arguments
+// CollectTypesFromQueryDocuments returns a map of type names used in query documents,
+// both from variable definitions (input types) and enum types from the selection set (return types).
 func CollectTypesFromQueryDocuments(schema *ast.Schema, queryDocuments []*ast.QueryDocument) map[string]bool {
 	usedTypes := make(map[string]bool)
 	processedTypes := make(map[string]bool) // 完全に処理済みの型を追跡
@@ -91,10 +92,32 @@ func CollectTypesFromQueryDocuments(schema *ast.Schema, queryDocuments []*ast.Qu
 					}
 				}
 			}
+			collectEnumsFromSelectionSet(op.SelectionSet, schema, usedTypes)
 		}
 	}
 
 	return usedTypes
+}
+
+func collectEnumsFromSelectionSet(ss ast.SelectionSet, schema *ast.Schema, usedTypes map[string]bool) {
+	for _, sel := range ss {
+		switch s := sel.(type) {
+		case *ast.Field:
+			if s.Definition != nil {
+				typeName := s.Definition.Type.Name()
+				if def, ok := schema.Types[typeName]; ok && def.Kind == ast.Enum {
+					usedTypes[typeName] = true
+				}
+			}
+			collectEnumsFromSelectionSet(s.SelectionSet, schema, usedTypes)
+		case *ast.InlineFragment:
+			collectEnumsFromSelectionSet(s.SelectionSet, schema, usedTypes)
+		case *ast.FragmentSpread:
+			if s.Definition != nil {
+				collectEnumsFromSelectionSet(s.Definition.SelectionSet, schema, usedTypes)
+			}
+		}
+	}
 }
 
 func collectInputObjectFieldsWithCycle(def *ast.Definition, schema *ast.Schema, usedTypes, processedTypes map[string]bool) {

--- a/querydocument/query_document_test.go
+++ b/querydocument/query_document_test.go
@@ -1,0 +1,159 @@
+package querydocument_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+
+	"github.com/gqlgo/gqlgenc/querydocument"
+)
+
+const testSchema = `
+type Query {
+	todos: [Todo!]!
+	todosBySortOrder(order: SortOrder!): [Todo!]!
+}
+
+type Mutation {
+	createTodos(input: NewTodos!): TodoPage
+}
+
+type Todo {
+	id: ID!
+	text: String!
+	status: TodoStatus!
+	unusedField: UnusedEnum
+}
+
+type TodoPage {
+	todos: [Todo!]!
+}
+
+input NewTodo {
+	text: String!
+	userId: String!
+}
+
+input NewTodos {
+	todos: [NewTodo!]!
+}
+
+enum TodoStatus {
+	OPEN
+	DONE
+}
+
+enum SortOrder {
+	ASC
+	DESC
+}
+
+enum UnusedEnum {
+	FOO
+	BAR
+}
+`
+
+func loadSchemaAndQuery(t *testing.T, query string) (*ast.Schema, []*ast.QueryDocument) {
+	t.Helper()
+
+	schema := gqlparser.MustLoadSchema(&ast.Source{Input: testSchema})
+	doc, errs := gqlparser.LoadQuery(schema, query)
+	require.Empty(t, errs)
+
+	docs, err := querydocument.QueryDocumentsByOperations(schema, doc.Operations)
+	require.NoError(t, err)
+
+	return schema, docs
+}
+
+func TestCollectTypesFromQueryDocuments(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enum in response field", func(t *testing.T) {
+		t.Parallel()
+
+		schema, docs := loadSchemaAndQuery(t, `
+			mutation CreateMany($todos: NewTodos!) {
+				createTodos(input: $todos) {
+					todos { id status }
+				}
+			}
+		`)
+
+		usedTypes := querydocument.CollectTypesFromQueryDocuments(schema, docs)
+
+		require.True(t, usedTypes["TodoStatus"], "enum selected in response should be collected")
+		require.False(t, usedTypes["UnusedEnum"], "enum not selected in any query should not be collected")
+		require.False(t, usedTypes["SortOrder"], "enum not referenced in this query should not be collected")
+	})
+
+	t.Run("enum only as argument", func(t *testing.T) {
+		t.Parallel()
+
+		schema, docs := loadSchemaAndQuery(t, `
+			query GetBySortOrder($order: SortOrder!) {
+				todosBySortOrder(order: $order) { id }
+			}
+		`)
+
+		usedTypes := querydocument.CollectTypesFromQueryDocuments(schema, docs)
+
+		require.True(t, usedTypes["SortOrder"], "enum used only as operation argument should be collected")
+		require.False(t, usedTypes["TodoStatus"], "enum not referenced in this query should not be collected")
+		require.False(t, usedTypes["UnusedEnum"], "unreferenced enum should not be collected")
+	})
+
+	t.Run("input types from variables", func(t *testing.T) {
+		t.Parallel()
+
+		schema, docs := loadSchemaAndQuery(t, `
+			mutation CreateMany($todos: NewTodos!) {
+				createTodos(input: $todos) {
+					todos { id }
+				}
+			}
+		`)
+
+		usedTypes := querydocument.CollectTypesFromQueryDocuments(schema, docs)
+
+		require.True(t, usedTypes["NewTodos"], "input type from variable definition should be collected")
+		require.True(t, usedTypes["NewTodo"], "nested input type should be collected recursively")
+	})
+
+	t.Run("multiple queries", func(t *testing.T) {
+		t.Parallel()
+
+		schema := gqlparser.MustLoadSchema(&ast.Source{Input: testSchema})
+
+		q1, errs := gqlparser.LoadQuery(schema, `
+			mutation CreateMany($todos: NewTodos!) {
+				createTodos(input: $todos) {
+					todos { id status }
+				}
+			}
+		`)
+		require.Empty(t, errs)
+
+		q2, errs := gqlparser.LoadQuery(schema, `
+			query GetBySortOrder($order: SortOrder!) {
+				todosBySortOrder(order: $order) { id }
+			}
+		`)
+		require.Empty(t, errs)
+
+		allOps := append(q1.Operations, q2.Operations...)
+		docs, err := querydocument.QueryDocumentsByOperations(schema, allOps)
+		require.NoError(t, err)
+
+		usedTypes := querydocument.CollectTypesFromQueryDocuments(schema, docs)
+
+		require.True(t, usedTypes["TodoStatus"], "enum from response field should be collected")
+		require.True(t, usedTypes["SortOrder"], "enum from argument should be collected")
+		require.True(t, usedTypes["NewTodos"], "input type should be collected")
+		require.True(t, usedTypes["NewTodo"], "nested input type should be collected")
+		require.False(t, usedTypes["UnusedEnum"], "unreferenced enum should not be collected")
+	})
+}

--- a/querydocument/query_document_test.go
+++ b/querydocument/query_document_test.go
@@ -121,39 +121,30 @@ func TestCollectTypesFromQueryDocuments(t *testing.T) {
 
 		require.True(t, usedTypes["NewTodos"], "input type from variable definition should be collected")
 		require.True(t, usedTypes["NewTodo"], "nested input type should be collected recursively")
+		require.False(t, usedTypes["TodoStatus"], "enum not selected in response should not be collected")
+		require.False(t, usedTypes["UnusedEnum"], "unreferenced enum should not be collected")
 	})
 
-	t.Run("multiple queries", func(t *testing.T) {
+	t.Run("enum in fragment spread", func(t *testing.T) {
 		t.Parallel()
 
-		schema := gqlparser.MustLoadSchema(&ast.Source{Input: testSchema})
+		schema, docs := loadSchemaAndQuery(t, `
+			fragment TodoFields on Todo {
+				id
+				status
+			}
 
-		q1, errs := gqlparser.LoadQuery(schema, `
-			mutation CreateMany($todos: NewTodos!) {
-				createTodos(input: $todos) {
-					todos { id status }
+			query GetTodos {
+				todos {
+					...TodoFields
 				}
 			}
 		`)
-		require.Empty(t, errs)
-
-		q2, errs := gqlparser.LoadQuery(schema, `
-			query GetBySortOrder($order: SortOrder!) {
-				todosBySortOrder(order: $order) { id }
-			}
-		`)
-		require.Empty(t, errs)
-
-		allOps := append(q1.Operations, q2.Operations...)
-		docs, err := querydocument.QueryDocumentsByOperations(schema, allOps)
-		require.NoError(t, err)
 
 		usedTypes := querydocument.CollectTypesFromQueryDocuments(schema, docs)
 
-		require.True(t, usedTypes["TodoStatus"], "enum from response field should be collected")
-		require.True(t, usedTypes["SortOrder"], "enum from argument should be collected")
-		require.True(t, usedTypes["NewTodos"], "input type should be collected")
-		require.True(t, usedTypes["NewTodo"], "nested input type should be collected")
+		require.True(t, usedTypes["TodoStatus"], "enum selected inside a fragment spread should be collected")
 		require.False(t, usedTypes["UnusedEnum"], "unreferenced enum should not be collected")
 	})
+
 }


### PR DESCRIPTION
## Problem

When `onlyUsedModels: true` is set, `mutateHook` filters `build.Models` (structs) and wipes `build.Interfaces`, but never touches `build.Enums`. Every enum in the introspected schema leaks into `models_gen.go`.

Additionally, `CollectTypesFromQueryDocuments` only walks variable definitions (input types). Enum types used in return fields (e.g. `status: TodoStatus` in a query response) are never added to `usedTypes`.

## Fix

Both changes are gated behind `onlyUsedModels: true` — zero behavior change when the flag is off.

1. **Filter `build.Enums`** in `mutateHook` using the same `usedTypes` map
2. **Walk selection sets for enum types** via `collectEnumsFromSelectionSet` — handles direct fields, inline fragments, and fragment spreads

## Test

Extended `only_used_models` golden file testdata:

| Enum | Referenced in | Expected |
|------|--------------|----------|
| `TodoStatus` | Return field (`todos { status }`) | **Included** ✅ |
| `SortOrder` | Operation argument only (`$order: SortOrder!`) | **Included** ✅ |
| `UnusedEnum` | Field on `Todo`, but never queried | **Excluded** ✅ |

Added unit tests for `CollectTypesFromQueryDocuments` (`querydocument/query_document_test.go`):
- Enum in response field
- Enum only as operation argument
- Enum inside a fragment spread
- Input types from variable definitions
- Multiple queries combined

All existing tests pass.