### PR TITLE
fix(clientgenv2): normalize nil GenerateConfig to empty struct

### DIFF
--- a/clientgenv2/client.go
+++ b/clientgenv2/client.go
@@ -25,7 +25,7 @@ type Plugin struct {
 
 func New(queryDocument *ast.QueryDocument, operationQueryDocuments []*ast.QueryDocument, client config.PackageConfig, generateConfig *gqlgencConfig.GenerateConfig) *Plugin {
 	if generateConfig == nil {
-		generateConfig = &gqlgencConfig.GenerateConfig{}
+		generateConfig = new(gqlgencConfig.GenerateConfig)
 	}
 	return &Plugin{
 		queryDocument:           queryDocument,
@@ -37,7 +37,7 @@ func New(queryDocument *ast.QueryDocument, operationQueryDocuments []*ast.QueryD
 
 func NewWithQueryDocument(queryFilePaths []string, client config.PackageConfig, generateConfig *gqlgencConfig.GenerateConfig) *Plugin {
 	if generateConfig == nil {
-		generateConfig = &gqlgencConfig.GenerateConfig{}
+		generateConfig = new(gqlgencConfig.GenerateConfig)
 	}
 	return &Plugin{
 		queryFilePaths: queryFilePaths,

--- a/clientgenv2/client.go
+++ b/clientgenv2/client.go
@@ -24,6 +24,9 @@ type Plugin struct {
 }
 
 func New(queryDocument *ast.QueryDocument, operationQueryDocuments []*ast.QueryDocument, client config.PackageConfig, generateConfig *gqlgencConfig.GenerateConfig) *Plugin {
+	if generateConfig == nil {
+		generateConfig = &gqlgencConfig.GenerateConfig{}
+	}
 	return &Plugin{
 		queryDocument:           queryDocument,
 		operationQueryDocuments: operationQueryDocuments,
@@ -33,6 +36,9 @@ func New(queryDocument *ast.QueryDocument, operationQueryDocuments []*ast.QueryD
 }
 
 func NewWithQueryDocument(queryFilePaths []string, client config.PackageConfig, generateConfig *gqlgencConfig.GenerateConfig) *Plugin {
+	if generateConfig == nil {
+		generateConfig = &gqlgencConfig.GenerateConfig{}
+	}
 	return &Plugin{
 		queryFilePaths: queryFilePaths,
 		Client:         client,

--- a/clientgenv2/client_test.go
+++ b/clientgenv2/client_test.go
@@ -1,0 +1,125 @@
+package clientgenv2
+
+import (
+	"testing"
+
+	"github.com/99designs/gqlgen/codegen/config"
+
+	gqlgencConfig "github.com/gqlgo/gqlgenc/config"
+)
+
+func TestNew_NilGenerateConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		generateConfig *gqlgencConfig.GenerateConfig
+	}{
+		{
+			name:           "success: nil generate config is normalized to empty struct",
+			generateConfig: nil,
+		},
+		{
+			name:           "success: non-nil generate config is preserved",
+			generateConfig: &gqlgencConfig.GenerateConfig{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := New(nil, nil, config.PackageConfig{}, tt.generateConfig)
+			if p.GenerateConfig == nil {
+				t.Fatal("Plugin.GenerateConfig must not be nil")
+			}
+		})
+	}
+}
+
+func TestNewWithQueryDocument_NilGenerateConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		generateConfig *gqlgencConfig.GenerateConfig
+	}{
+		{
+			name:           "success: nil generate config is normalized to empty struct",
+			generateConfig: nil,
+		},
+		{
+			name:           "success: non-nil generate config is preserved",
+			generateConfig: &gqlgencConfig.GenerateConfig{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := NewWithQueryDocument(nil, config.PackageConfig{}, tt.generateConfig)
+			if p.GenerateConfig == nil {
+				t.Fatal("Plugin.GenerateConfig must not be nil")
+			}
+		})
+	}
+}
+
+func TestNewSourceGenerator_NilGenerateConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		generateConfig *gqlgencConfig.GenerateConfig
+	}{
+		{
+			name:           "success: nil generate config is normalized to empty struct",
+			generateConfig: nil,
+		},
+		{
+			name:           "success: non-nil generate config is preserved",
+			generateConfig: &gqlgencConfig.GenerateConfig{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sg := NewSourceGenerator(&config.Config{}, config.PackageConfig{}, tt.generateConfig)
+			if sg.generateConfig == nil {
+				t.Fatal("SourceGenerator.generateConfig must not be nil")
+			}
+		})
+	}
+}
+
+func TestNewSource_NilGenerateConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		generateConfig *gqlgencConfig.GenerateConfig
+	}{
+		{
+			name:           "success: nil generate config is normalized to empty struct",
+			generateConfig: nil,
+		},
+		{
+			name:           "success: non-nil generate config is preserved",
+			generateConfig: &gqlgencConfig.GenerateConfig{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := NewSource(nil, nil, nil, tt.generateConfig)
+			if s.generateConfig == nil {
+				t.Fatal("Source.generateConfig must not be nil")
+			}
+		})
+	}
+}

--- a/clientgenv2/source.go
+++ b/clientgenv2/source.go
@@ -21,6 +21,9 @@ type Source struct {
 }
 
 func NewSource(schema *ast.Schema, queryDocument *ast.QueryDocument, sourceGenerator *SourceGenerator, generateConfig *config.GenerateConfig) *Source {
+	if generateConfig == nil {
+		generateConfig = &config.GenerateConfig{}
+	}
 	return &Source{
 		schema:          schema,
 		queryDocument:   queryDocument,

--- a/clientgenv2/source.go
+++ b/clientgenv2/source.go
@@ -22,7 +22,7 @@ type Source struct {
 
 func NewSource(schema *ast.Schema, queryDocument *ast.QueryDocument, sourceGenerator *SourceGenerator, generateConfig *config.GenerateConfig) *Source {
 	if generateConfig == nil {
-		generateConfig = &config.GenerateConfig{}
+		generateConfig = new(config.GenerateConfig)
 	}
 	return &Source{
 		schema:          schema,

--- a/clientgenv2/source_generator.go
+++ b/clientgenv2/source_generator.go
@@ -221,6 +221,9 @@ type SourceGenerator struct {
 }
 
 func NewSourceGenerator(cfg *config.Config, client config.PackageConfig, generateConfig *gqlgencConfig.GenerateConfig) *SourceGenerator {
+	if generateConfig == nil {
+		generateConfig = &gqlgencConfig.GenerateConfig{}
+	}
 	return &SourceGenerator{
 		cfg:            cfg,
 		binder:         cfg.NewBinder(),

--- a/clientgenv2/source_generator.go
+++ b/clientgenv2/source_generator.go
@@ -222,7 +222,7 @@ type SourceGenerator struct {
 
 func NewSourceGenerator(cfg *config.Config, client config.PackageConfig, generateConfig *gqlgencConfig.GenerateConfig) *SourceGenerator {
 	if generateConfig == nil {
-		generateConfig = &gqlgencConfig.GenerateConfig{}
+		generateConfig = new(gqlgencConfig.GenerateConfig)
 	}
 	return &SourceGenerator{
 		cfg:            cfg,


### PR DESCRIPTION
## Summary

`clientgenv2.New`, `NewWithQueryDocument`, `NewSourceGenerator`, and `NewSource` panic when callers pass a nil `*GenerateConfig`. Direct field accesses introduced for `EnableClientJsonOmitemptyTag`, `EnableClientJsonOmitzeroTag`, and `InlineFragmentAlwaysPointers` dereference the nil pointer before any guard runs.

This affects external library consumers that build a `Plugin` directly without going through `config.LoadConfig` (which would otherwise normalize `cfg.Generate`).

## Why

The internal call site (`generator/generator.go`) always passes a non-nil `cfg.Generate` because `LoadConfig` defaults it. The exported constructors do not enforce that invariant, so nil-input paths panic at runtime.

## What changed

- Normalize `nil` to `&GenerateConfig{}` at each public constructor:
  - `clientgenv2.New`
  - `clientgenv2.NewWithQueryDocument`
  - `clientgenv2.NewSourceGenerator`
  - `clientgenv2.NewSource`
- Existing inner nil checks on individual fields (`Prefix`, `Suffix`, `EnableClientJsonOmitemptyTag`, etc.) keep working unchanged.
- Add table-driven tests covering nil and non-nil inputs for all four constructors.
