### PR TITLE
feat(clientv2): add option to encode nil slices as empty arrays

### DIFF
--- a/clientv2/client.go
+++ b/clientv2/client.go
@@ -90,6 +90,7 @@ type Client struct {
 	CustomDo                   RequestInterceptorFunc
 	ParseDataWhenErrors        bool
 	IsUnsafeRequestInterceptor bool
+	EncodeNilSliceAsEmptyArray bool
 }
 
 // Request represents an outgoing GraphQL request
@@ -111,6 +112,7 @@ func NewClient(client HttpClient, baseURL string, options *Options, interceptors
 
 	if options != nil {
 		c.ParseDataWhenErrors = options.ParseDataAlongWithErrors
+		c.EncodeNilSliceAsEmptyArray = options.EncodeNilSliceAsEmptyArray
 	}
 
 	return c
@@ -128,6 +130,7 @@ func NewClientWithUnsafeRequestInterceptor(client HttpClient, baseURL string, op
 
 	if options != nil {
 		c.ParseDataWhenErrors = options.ParseDataAlongWithErrors
+		c.EncodeNilSliceAsEmptyArray = options.EncodeNilSliceAsEmptyArray
 	}
 
 	return c
@@ -138,6 +141,11 @@ type Options struct {
 	// ParseDataAlongWithErrors is a flag that indicates whether the client should try to parse and return the data along with error
 	// when error appeared. So in the end you'll get list of gql errors and data.
 	ParseDataAlongWithErrors bool
+	// EncodeNilSliceAsEmptyArray is a flag that indicates whether the client should encode nil slices
+	// in request variables as [] instead of null. This restores the encoding behavior prior to
+	// https://github.com/gqlgo/gqlgenc/pull/265, which is useful when a server schema declares
+	// non-null list inputs (e.g. [Item!]!) that reject null.
+	EncodeNilSliceAsEmptyArray bool
 }
 
 // GqlErrorList is the struct of a standard graphql error response
@@ -232,7 +240,7 @@ func (c *Client) Post(ctx context.Context, operationName, query string, respData
 
 		headers = append(headers, header{key: "Content-Type", value: contentType})
 	} else {
-		requestBody, err := MarshalJSON(ctx, r)
+		requestBody, err := c.marshalJSON(r)
 		if err != nil {
 			return fmt.Errorf("encode: %w", err)
 		}
@@ -478,8 +486,18 @@ func MarshalJSON(_ context.Context, v any) ([]byte, error) {
 	return encoder.Encode(reflect.ValueOf(v))
 }
 
+// marshalJSON encodes a request body honoring the client's encoder options.
+func (c *Client) marshalJSON(v any) ([]byte, error) {
+	encoder := &Encoder{NilSliceAsEmptyArray: c.EncodeNilSliceAsEmptyArray}
+	return encoder.Encode(reflect.ValueOf(v))
+}
+
 // Encoder is a struct for encoding GraphQL requests to JSON
-type Encoder struct{}
+type Encoder struct {
+	// NilSliceAsEmptyArray encodes nil slices as [] instead of null.
+	// See Options.EncodeNilSliceAsEmptyArray for details.
+	NilSliceAsEmptyArray bool
+}
 
 // fieldInfo holds field information of a struct
 type fieldInfo struct {
@@ -493,6 +511,10 @@ type fieldInfo struct {
 // Encode encodes any value to JSON
 func (e *Encoder) Encode(v reflect.Value) ([]byte, error) {
 	if !v.IsValid() || isNil(v) {
+		if e.NilSliceAsEmptyArray && v.IsValid() && v.Kind() == reflect.Slice {
+			return []byte("[]"), nil
+		}
+
 		return []byte("null"), nil
 	}
 
@@ -774,6 +796,10 @@ func (e *Encoder) encodeMap(v reflect.Value) ([]byte, error) {
 // encodeSlice encodes a slice value
 func (e *Encoder) encodeSlice(v reflect.Value) ([]byte, error) {
 	if v.IsNil() {
+		if e.NilSliceAsEmptyArray {
+			return []byte("[]"), nil
+		}
+
 		return []byte("null"), nil
 	}
 

--- a/clientv2/client_test.go
+++ b/clientv2/client_test.go
@@ -1874,3 +1874,143 @@ func Test_isZeroValue(t *testing.T) {
 		})
 	}
 }
+
+func TestEncoderNilSliceAsEmptyArray(t *testing.T) {
+	t.Parallel()
+
+	type input struct {
+		Items    []string  `json:"items"`
+		Optional []string  `json:"optional,omitempty"`
+		Ptr      *[]string `json:"ptr"`
+	}
+
+	tests := []struct {
+		name                 string
+		nilSliceAsEmptyArray bool
+		v                    any
+		want                 string
+	}{
+		{
+			name:                 "nil slice encodes as null by default",
+			nilSliceAsEmptyArray: false,
+			v:                    []string(nil),
+			want:                 `null`,
+		},
+		{
+			name:                 "nil slice encodes as empty array when enabled",
+			nilSliceAsEmptyArray: true,
+			v:                    []string(nil),
+			want:                 `[]`,
+		},
+		{
+			name:                 "empty slice encodes as empty array regardless of the flag",
+			nilSliceAsEmptyArray: false,
+			v:                    []string{},
+			want:                 `[]`,
+		},
+		{
+			name:                 "nil slice struct field encodes as null by default",
+			nilSliceAsEmptyArray: false,
+			v:                    input{},
+			want:                 `{"items":null,"ptr":null}`,
+		},
+		{
+			name:                 "nil slice struct field encodes as empty array when enabled",
+			nilSliceAsEmptyArray: true,
+			v:                    input{},
+			want:                 `{"items":[],"ptr":null}`,
+		},
+		{
+			name:                 "omitempty still skips nil slice fields when enabled",
+			nilSliceAsEmptyArray: true,
+			v:                    input{Items: []string{"a"}},
+			want:                 `{"items":["a"],"ptr":null}`,
+		},
+		{
+			name:                 "nested nil slices encode as empty arrays when enabled",
+			nilSliceAsEmptyArray: true,
+			v:                    [][]int{nil, {1}},
+			want:                 `[[],[1]]`,
+		},
+		{
+			name:                 "nil map value slice encodes as empty array when enabled",
+			nilSliceAsEmptyArray: true,
+			v:                    map[string][]int{"a": nil},
+			want:                 `{"a":[]}`,
+		},
+		{
+			name:                 "nil pointer to slice encodes as null even when enabled",
+			nilSliceAsEmptyArray: true,
+			v:                    (*[]string)(nil),
+			want:                 `null`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			encoder := &Encoder{NilSliceAsEmptyArray: tt.nilSliceAsEmptyArray}
+
+			got, err := encoder.Encode(reflect.ValueOf(tt.v))
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+type captureHTTPClient struct {
+	body []byte
+}
+
+func (c *captureHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	c.body = body
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewBufferString(validData)),
+		Header:     http.Header{},
+	}, nil
+}
+
+func (c *captureHTTPClient) Post(_, _ string, _ io.Reader) (*http.Response, error) {
+	return nil, errors.New("unexpected call")
+}
+
+func TestClientPostEncodeNilSliceAsEmptyArray(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		options *Options
+		want    string
+	}{
+		{
+			name:    "nil slice variable is sent as null by default",
+			options: nil,
+			want:    `{"query":"mutation { noop }","variables":{"ids":null},"operationName":"Noop"}`,
+		},
+		{
+			name:    "nil slice variable is sent as empty array when the option is enabled",
+			options: &Options{EncodeNilSliceAsEmptyArray: true},
+			want:    `{"query":"mutation { noop }","variables":{"ids":[]},"operationName":"Noop"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			httpClient := &captureHTTPClient{}
+			client := NewClient(httpClient, "https://example.com/graphql", tt.options)
+
+			res := &fakeRes{}
+			err := client.Post(context.Background(), "Noop", "mutation { noop }", res, map[string]any{"ids": []string(nil)})
+			require.NoError(t, err)
+			require.JSONEq(t, tt.want, string(httpClient.body))
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds an opt-in flag `Options.EncodeNilSliceAsEmptyArray` (and the corresponding `Encoder.NilSliceAsEmptyArray` field) that encodes nil slices in request variables as `[]` instead of `null`.

## Why

Since #265, nil slices are encoded as `null`. That is a reasonable default, but it breaks clients talking to servers whose schema declares non-null list inputs (e.g. `items: [Item!]!`): sending `null` for such variables is rejected with a `cannot be null` error, while `[]` is accepted. Before #265, nil slices were encoded as `[]`, so existing codebases upgrading from older versions can hit this on every mutation that leaves a slice field unset.

This PR restores that behavior as an explicit opt-in, without changing the default:

```go
client := clientv2.NewClient(httpClient, endpoint, &clientv2.Options{
    EncodeNilSliceAsEmptyArray: true,
})
```

Since generated clients pass `*clientv2.Options` straight through to `clientv2.NewClient`, no generator/template changes are needed.

## Notes

- Default behavior is unchanged (`null`); the flag is opt-in.
- The package-level `MarshalJSON` is untouched for backward compatibility; the client now uses an internal helper that honors its options.
- A nil `*[]T` (pointer to slice) still encodes as `null` even with the flag enabled — only nil slices themselves are affected.
- `omitempty` fields are still skipped as before; the flag only affects fields that are actually serialized.

## Testing

- `make test` passes.
- `golangci-lint v2.12.2` (same as CI): 0 issues.
- Added table-driven tests for the encoder (top-level / struct field / nested / map value / nil pointer cases) and a `Client.Post` test asserting the wire format with and without the option.